### PR TITLE
Feature #27 create average maps

### DIFF
--- a/ExploreASL.m
+++ b/ExploreASL.m
@@ -1,0 +1,36 @@
+function [x] = ExploreASL(var1, var2, var3, var4, var5, var6)
+%ExploreASL Alias to ExploreASL_Master
+%
+% FORMAT: [x] = ExploreASL([DataParPath, ProcessData, SkipPause, iWorker, nWorkers, iModules])
+%                         
+% -----------------------------------------------------------------------------------------------------------------------------------------------------
+% DESCRIPTION: This function calls the masterscript ExploreASL_Master.
+% Please type help ExploreASL_Master for more explanation.
+% The function ExploreASL_Master will be renamed into ExploreASL with
+% version 2.0.
+% __________________________________
+% Copyright 2015-2020 ExploreASL
+
+if nargin<6
+    var6 = [];
+end
+if nargin<5
+    var5 = [];
+end
+if nargin<4
+    var4 = [];
+end
+if nargin<3
+    var3 = [];
+end
+if nargin<2
+    var2 = [];
+end
+if nargin<1
+    var1 = [];
+end
+
+x = ExploreASL_Master(var1, var2, var3, var4, var5, var6);
+
+
+end

--- a/ExploreASL_Master.m
+++ b/ExploreASL_Master.m
@@ -74,7 +74,7 @@ function [x] = ExploreASL_Master(DataParPath, ProcessData, SkipPause, iWorker, n
 
     x = ExploreASL_Initialize(DataParPath, ProcessData, iWorker, nWorkers);
     
-    if ~x.ProcessData
+    if x.ProcessData==0 || x.ProcessData==2
         return; % skip processing
     elseif ~isdeployed && ~SkipPause % if this exists, we skip the break here
         fprintf('%s\n','Press any key to start processing & analyzing');

--- a/ExploreASL_Master.m
+++ b/ExploreASL_Master.m
@@ -1,11 +1,14 @@
 function [x] = ExploreASL_Master(DataParPath, ProcessData, SkipPause, iWorker, nWorkers, iModules)
 %ExploreASL_Master ExploreASL pipeline master wrapper calling the individual pipeline modules
 %
-% FORMAT: [x] = ExploreASL_Master([DataParPath, ProcessData, SkipPause, iWorker, nWorkers, iModules])
+% FORMAT: [x] = ExploreASL([DataParPath, ProcessData, SkipPause, iWorker, nWorkers, iModules])
 % 
 % INPUT:
 %   DataParPath - path to data parameter file (OPTIONAL, required when ProcessData=true, will then be prompted if omitted)
-%   ProcessData - true if running pipeline on data, false if only initializing ExploreASL (e.g. path management etc, REQUIRED, will be prompted if omitted)
+%   ProcessData - 0 = only initialize ExploreASL functionality (e.g. path management etc, REQUIRED, will be prompted if omitted)
+%               - 1 = initialize ExploreASL functionality, load data & start processing pipeline, 
+%               - 2 = initialize ExploreASL functionality, load data but no processing
+%               - (OPTIONAL, default=prompt the user)
 %   SkipPause   - true if calling pipeline without pausing for questioning for user prompting (OPTIONAL, DEFAULT=false)
 %   iWorker     - allows parallelization when called externally. iWorker defines which of the parallel ExploreASL calls we are (OPTIONAL, DEFAULT=1)
 %   nWorkers    - allows parallelization when called externally. nWorkers defines how many ExploreASL calls are made in parallel (OPTIONAL, DEFAULT=1)
@@ -29,11 +32,11 @@ function [x] = ExploreASL_Master(DataParPath, ProcessData, SkipPause, iWorker, n
 % xASL_Module_Population - processes data on population basis, mostly QC, but also template/parametric maps creation, etc. Type help xASL_module_Population for more information 
 % 
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% EXAMPLE for GUI: ExploreASL_Master
-% EXAMPLE for calling externally: ExploreASL_Master('//MyDisk/MyStudy/DataPar.m', true, true);
-% EXAMPLE for calling externally to run the Structural module only: ExploreASL_Master('//MyDisk/MyStudy/DataPar.m', true, true, [], [], 1);
-% EXAMPLE for calling externally to run the ASL & Population modules: ExploreASL_Master('//MyDisk/MyStudy/DataPar.m', true, true, [], [], [2 3]);
-% EXAMPLE for debugging/initialization only: [x] = ExploreASL_Master('',0);
+% EXAMPLE for GUI: ExploreASL
+% EXAMPLE for calling externally: ExploreASL('//MyDisk/MyStudy/DataPar.m', true, true);
+% EXAMPLE for calling externally to run the Structural module only: ExploreASL('//MyDisk/MyStudy/DataPar.m', true, true, [], [], 1);
+% EXAMPLE for calling externally to run the ASL & Population modules: ExploreASL('//MyDisk/MyStudy/DataPar.m', true, true, [], [], [2 3]);
+% EXAMPLE for debugging/initialization only: [x] = ExploreASL('',0);
 % __________________________________
 % Copyright 2015-2020 ExploreASL
 

--- a/Functions/xASL_bids_Add2ParticipantsTSV.m
+++ b/Functions/xASL_bids_Add2ParticipantsTSV.m
@@ -168,9 +168,9 @@ for iIndex=1:size(DataIn,1)
         continue;
     end     
     
-    IsEmpty = isempty(CellArray{iRow+1,DataColumn}) || strcmp(CellArray{iRow+1,DataColumn}, 'n/a');
+    IsEmpty = size(CellArray,1)<iRow || isempty(CellArray{iRow,DataColumn}) || strcmp(CellArray{iRow,DataColumn}, 'n/a');
     if IsEmpty || bOverwrite
-        CellArray{iRow+1,DataColumn} = DataIn{iIndex,3};
+        CellArray{iRow+1,DataColumn} = DataIn{iIndex,3}; % iRow+1 for header
     else
         fprintf('Data already existing, skipping\n');
     end

--- a/Functions/xASL_init_DefineStudyData.m
+++ b/Functions/xASL_init_DefineStudyData.m
@@ -89,6 +89,7 @@ x.nTotalSubjects = length(x.TotalSubjects);
 
 % ------------------------------------------------------------------------------------------------
 %% 2) Create dummy defaults (exclusion list, ASL sessions)
+fprintf('Automatically defining sessions...\n');
 if ~isfield(x,'exclusion') % default no exclusions
     x.exclusion = {''};
 end
@@ -228,7 +229,7 @@ if x.nSessions>1  % if there are sessions (more than 1 session), then sessions=1
         x.S.SetsOptions{1} = x.session.options; % with session options (e.g. morning, evening 2nd morning)
     else
         for iS=1:x.nSessions
-            x.S.SetsOptions{1}{iS} = ['Session_' num2str(iS)];
+            x.S.SetsOptions{1}{iS} = ['ASL_' num2str(iS)];
         end
     end        
     

--- a/Modules/SubModule_Population/xASL_wrp_CreatePopulationTemplates.m
+++ b/Modules/SubModule_Population/xASL_wrp_CreatePopulationTemplates.m
@@ -44,6 +44,15 @@ function xASL_wrp_CreatePopulationTemplates(x, bSaveUnmasked, bCompute4Sets, Spe
 % is similar between different subjects. Other parametric maps can be
 % decommented (now commented out for speed).
 %
+% Any new addition to participants.tsv will be recognized and loaded, for
+% the generation of new parametric maps for groups specifically
+% (needs to be set in input argument bCompute4Sets)
+%
+% If a set only includes a combination of the following SetOptions:
+% left, right, l, r, n/a, NaN (irrespective of capitals)
+% each image with option right/r, will be flipped in the left-right
+% direction, and left/right will not be treated as separate groups.
+%
 % EXAMPLE: xASL_wrp_CreatePopulationTemplates(x);
 % EXAMPLE for specific scantypes:
 %          xASL_wrp_CreatePopulationTemplates(x, [], [], {{'qCBF'} {'CBF'} 1});

--- a/Modules/SubModule_Population/xASL_wrp_CreatePopulationTemplates.m
+++ b/Modules/SubModule_Population/xASL_wrp_CreatePopulationTemplates.m
@@ -1,4 +1,4 @@
-function xASL_wrp_CreatePopulationTemplates(x, SaveUnmasked, bCompute4Sets, SpecificScantype, bSkipMissingScans, bRemoveOutliers, FunctionsAre)
+function xASL_wrp_CreatePopulationTemplates(x, bSaveUnmasked, bCompute4Sets, SpecificScantype, bSkipMissingScans, bRemoveOutliers, FunctionsAre)
 %xASL_wrp_CreatePopulationTemplates ExploreASL Population module wrapper,
 %creates population parametric images for each ScanType
 %
@@ -6,9 +6,12 @@ function xASL_wrp_CreatePopulationTemplates(x, SaveUnmasked, bCompute4Sets, Spec
 %
 % INPUT:
 %   x            - structure containing fields with all information required to run the population module (REQUIRED)
-%   SaveUnmasked - allows saving the same images without masking (OPTIONAL, DEFAULT=true)
+%   bSaveUnmasked - allows saving the same images without masking (OPTIONAL, DEFAULT=true)
 %   bCompute4Sets - creates the same parametric images for subsets of the
-%                  data (e.g. cohorts, sites, etc) (OPTIONAL, DEFAULT=false)
+%                  data (e.g. cohorts, sites, etc)
+%                  can be a Boolean for computing for all subsets (1) or
+%                  none (0), or a cell structure with the names of the
+%                  subsets to compute for. (OPTIONAL, DEFAULT=0)
 %   SpecificScantype - allows providing ScanTypes to create templates for:
 %                      should be 3 cells:
 %                      SpecificScantype{1} = PreFixList (prefix string of the NIfTI, associated with the ScanType, e.g. 'qCBF', 'PV_PGM', etc)
@@ -54,11 +57,21 @@ function xASL_wrp_CreatePopulationTemplates(x, SaveUnmasked, bCompute4Sets, Spec
 %% ----------------------------------------------------------------------------------------------------
 %  Admin
 
-if nargin<2 || isempty(SaveUnmasked)
-    SaveUnmasked = true;
+if nargin<2 || isempty(bSaveUnmasked)
+    bSaveUnmasked = true;
 end
 if nargin<3 || isempty(bCompute4Sets)
-    bCompute4Sets = false;
+    bCompute4Sets = 0;
+elseif iscell(bCompute4Sets)
+    Sets2Check = bCompute4Sets;
+    bCompute4Sets = 1;
+elseif bCompute4Sets==1
+    Sets2Check = [];
+elseif bCompute4Sets==0
+    % do nothing
+else
+    error('Invalid bComputeSets option, skipping');
+    return;
 end
 if nargin<5 || isempty(bSkipMissingScans)
     bSkipMissingScans = true;
@@ -94,15 +107,21 @@ x.D.TemplatesStudyDir = fullfile(x.D.PopDir, 'Templates');
 xASL_adm_CreateDir(x.D.TemplatesStudyDir);
 
 if bCompute4Sets
-    % Define sets to create comparative stats for
-    NextN = 1;
-    for iSet=1:size(x.S.SetsID,2)
-        TempUnique = unique(x.S.SetsID(:,iSet));
-        nUniqueValues = length(TempUnique(~isnan(TempUnique)));
-        if  nUniqueValues>1 && nUniqueValues<6
-            Sets2Check(NextN,1) = iSet;
-            NextN = NextN+1;
+    % Reload set parameters to be sure
+    x = xASL_init_LoadMetadata(x); % Add statistical variables, if there are new ones
+    
+    if isempty(Sets2Check)
+        % Define sets to create comparative stats for
+        for iSet=1:size(x.S.SetsID,2)
+            TempUnique = unique(x.S.SetsID(:,iSet));
+            nUniqueValues = length(TempUnique(~isnan(TempUnique)));
+            if  nUniqueValues>1 && nUniqueValues<6
+                Sets2Check(end+1,1) = iSet;
+            end
         end
+    else
+        % convert names of sets to indices
+        Sets2Check = find(cellfun(@(y) strcmp(Sets2Check, y), x.S.SetsName));
     end
 end
 
@@ -190,7 +209,7 @@ end
 % Loading data
 for iScanType=1:length(PreFixList)
     UnAvailable = 0;
-    NextN = 1;
+    
 
     fprintf(['Searching ' TemplateNameList{iScanType} ' images:   ']);
     for iSession=1:x.nSessions
@@ -202,17 +221,19 @@ for iScanType=1:length(PreFixList)
         elseif iSession>1  && ~SessionsExist(iScanType)
                 % For structural scans, there are no sessions>1, so
                 % skip this
-                UseThisSession  = 0;
+                UseThisSession = 0;
+                continue; % skip this session
         elseif SessionsExist(iScanType)
                 SessionAppendix = ['_' x.SESSIONS{iSession}];
                 UseThisSession = 1;
         end
 
         % ----------------------------------------------------------------------------------------------------
-        % Predefine memory
-        clear IM IM2 LoadFiles
+        % Predefine & clear memory
+        IM = 0;
+        IM2noMask = 0;
+        LoadFiles = '';
         UnAvailable = 0;
-        NextN = 1;
         NoImageN = 1;
         % Searching for available images
         if UseThisSession
@@ -223,8 +244,7 @@ for iScanType=1:length(PreFixList)
 
                 if xASL_exist(PathNII,'file')
                     % If exist, add this subject/image to the list
-                    LoadFiles{NextN,1} = PathNII;
-                    NextN = NextN+1;
+                    LoadFiles{end+1,1} = PathNII;
                     xASL_io_ReadNifti(PathNII);
                 else
                     % if doesnt exist, dont add to the list
@@ -238,8 +258,8 @@ for iScanType=1:length(PreFixList)
             if ~UseThisSession
                 continue;
             elseif UseThisSession && ~exist('LoadFiles','var')
-                    fprintf('\n%s',['No ' PreFixList{iScanType} ' files found, skipping...']);
-                    continue;
+                fprintf('\n%s',['No ' PreFixList{iScanType} ' files found, skipping...']);
+                continue;
             end
         end
 
@@ -261,7 +281,7 @@ for iScanType=1:length(PreFixList)
         end
 
         IM = zeros(Size1,nSize,'single'); % pre-allocating for speed
-        if SaveUnmasked; IM2 = zeros(121,145,121,nSize, 'single'); end
+        if bSaveUnmasked; IM2noMask = zeros(121,145,121,nSize, 'single'); end
 
         for iSubject=1:nLoad % add images
             xASL_TrackProgress(iSubject,nLoad);
@@ -274,7 +294,7 @@ for iScanType=1:length(PreFixList)
                 continue; % proceed with next ScanType
             end
             IM(:,iSubject) = tempIM1;
-            if SaveUnmasked; IM2(:,:,:,iSubject) = tempIM; end
+            if bSaveUnmasked; IM2noMask(:,:,:,iSubject) = tempIM; end
         end
         fprintf('\n');
 
@@ -286,64 +306,125 @@ for iScanType=1:length(PreFixList)
         end
 
         % create the maps
-        NameIM = TemplateNameList{iScanType};
+        NameIM = [TemplateNameList{iScanType} '_n=' num2str(length(NotOutliers))];
         ComputeParametricImages(IM(:,NotOutliers),NameIM, x, FunctionsAre, true);
 
-        if SaveUnmasked
-            ComputeParametricImages(IM2(:,:,:,NotOutliers),NameIM, x, FunctionsAre, false);
+        if bSaveUnmasked
+            ComputeParametricImages(IM2noMask(:,:,:,NotOutliers),NameIM, x, FunctionsAre, false);
         end
         % ----------------------------------------------------------------------------------------------------
         % This part checks for individual sets (e.g. create statistic images for each cohort/session etc)
-        if bCompute4Sets
+        if ~bCompute4Sets
+            % not requested, skipping
+            continue;
+        elseif isempty(Sets2Check)
+            fprintf('\n');
+            warning('There are no sets that we can create statistical maps for');
+            continue;
+        else
             for iSet=1:length(Sets2Check)
+                % First validate that this set doesnt have continuous data
+                if x.S.Sets1_2Sample(Sets2Check(iSet))==3
+                    warning(['Cannot create maps for non-ordinal set ' x.S.SetsName{Sets2Check(iSet)} ', skipping'])
+                    continue;
+                end
+                
+                % Obtain unique options for this set
                 TempUnique = unique(x.S.SetsID(:,Sets2Check(iSet)));
                 UniqueSet = TempUnique(~isnan(TempUnique));
                 % Now if we have a 0, switch it to 1
                 % This can happen if we have a set with string options, where
                 % the first string is a 0, and then translated into a number.
                 % This should be then index==1 for SetsOptions
-                IndZero = find(UniqueSet==0);
-                if ~isempty(IndZero) && sum(UniqueSet==1)==0
-                    UniqueSet(IndZero) = 1;
+                IndexZero = find(UniqueSet==0);
+                if ~isempty(IndexZero) && sum(UniqueSet==1)==0
+                    UniqueSet(IndexZero) = 1;
                 end
-                for iU=1:length(UniqueSet)
-                    if ~SessionsExist(iScanType) && ~isempty(findstr(x.S.SetsName{Sets2Check(iSet)},'session'))
-                        % This SET is for sessions, but there are no sessions for this scantype
-                        % So skip this
-                    else
-                        try
-                            WithinGroup = x.S.SetsID(:,Sets2Check(iSet))==UniqueSet(iU);
-
-                            if ~SessionsExist(iScanType) % if no sessions exist, only take current session here
-                                CurrSess = [1:x.nSessions:x.nSubjectsSessions]' + (iSession-1);
-                                WithinGroup = WithinGroup(CurrSess);
+                
+                SetOptions = lower(x.S.SetsOptions{Sets2Check(iSet)});
+                tempIM = IM;
+                if bSaveUnmasked
+                    tempIM2noMask = IM2noMask;
+                end
+                
+                % if the only options are left & right (and n/a for missing), assume that this is
+                % a request to flip hemispheres for the 'right' ones
+                bFlipHemisphere = min(cellfun(@(y) ~isempty(regexp(y, '^(left|right|l|r|n/a|nan)$')), SetOptions));
+                
+                if bFlipHemisphere
+                    % get option index for right
+                    Index2Flip = find(cellfun(@(y) ~isempty(regexp(y, '^(right|r)$')), SetOptions));
+                    Images2Flip = x.S.SetsID(:,Sets2Check(iSet))==Index2Flip;
+                    
+                    % Flip the images
+                    % we iterate this, to avoid using large memory
+                    fprintf('Flipping images:   ');
+                    for iImage=1:size(tempIM,2)
+                        xASL_TrackProgress(iImage, size(tempIM,2));
+                        if Images2Flip(iImage)
+                            tIM = xASL_im_Column2IM(tempIM(:,iImage), x.WBmask);
+                            tIM = fliplr(tIM);
+                            tempIM(:,iImage) = xASL_im_IM2Column(tIM, x.WBmask);
+                            if bSaveUnmasked
+                                tempIM2noMask(:,:,:,iImage) = fliplr(tempIM2noMask(:,:,:,iImage));
                             end
-
-                            % select those within the set/group only
-                            NameIM = [TemplateNameList{iScanType} '_' x.S.SetsName{Sets2Check(iSet)} '_' x.S.SetsOptions{Sets2Check(iSet)}{UniqueSet(iU)}];
-                            tempIM = IM(:,WithinGroup);
-
-                            if bRemoveOutliers
-                                % Exclude outliers
-                                NotOutliers = find(xASL_stat_RobustMean(tempIM))';
-                            else
-                                NotOutliers = [1:1:size(tempIM,2)];
-                            end
-                            
-                            % compute maps
-                            ComputeParametricImages(tempIM(:,NotOutliers), NameIM, x, FunctionsAre, true);
-                            if SaveUnmasked
-                                tempIM2 = IM2(:,:,:,WithinGroup);
-                                ComputeParametricImages(tempIM2(:,:,:,NotOutliers),NameIM, x, false);
-                            end
-                        catch ME
-                            warning('Getting set didnt work');
-                            fprintf('%s\n',ME.message);
                         end
                     end
+                    fprintf('\n');
+                    
+                    % now we change the set options & ID to inclusion
+                    % instead of left/right
+                    IndexInclusion = find(cellfun(@(y) ~isempty(regexp(y, '^(left|right|l|r)$')), SetOptions));
+                    SetID = ~max(x.S.SetsID(:,Sets2Check(iSet))==IndexInclusion, [], 2)+1;
+                    SetOptions = {'' 'n/a'};
+                    UniqueSet = [1;2];
+                    
+                else
+                    SetOptions = lower(x.S.SetsOptions{Sets2Check(iSet)});
+                    SetID = x.S.SetsID(:,Sets2Check(iSet));
                 end
-            end
-        end
+                
+                for iU=1:length(UniqueSet) % iterate over the options/categories of this set
+                    if ~isempty(regexp(SetOptions{UniqueSet(iU)}, '(n/a|nan)'))
+                        % skipping NaNs, consider them as outside of a group
+                        continue;
+                    elseif ~SessionsExist(iScanType) && ~isempty(findstr(x.S.SetsName{Sets2Check(iSet)}, 'session'))
+                        % This SET is for sessions, but there are no sessions for this scantype
+                        % So skip this
+                        continue;
+                    end
+                    try
+                        WithinGroup = SetID==UniqueSet(iU);
+
+                        if ~SessionsExist(iScanType) % if no sessions exist, only take current session here
+                            CurrSess = [1:x.nSessions:x.nSubjectsSessions]' + (iSession-1);
+                            WithinGroup = WithinGroup(CurrSess);
+                        end
+
+                        % select those within the set/group only
+                        tempIM = tempIM(:,WithinGroup);
+
+                        if bRemoveOutliers
+                            % Exclude outliers
+                            NotOutliers = find(xASL_stat_RobustMean(tempIM))';
+                        else
+                            NotOutliers = [1:1:size(tempIM,2)];
+                        end
+
+                        % compute maps
+                        NameIM = [TemplateNameList{iScanType} '_' x.S.SetsName{Sets2Check(iSet)} '_' SetOptions{UniqueSet(iU)} '_n=' num2str(length(NotOutliers))];
+                        ComputeParametricImages(tempIM(:,NotOutliers), NameIM, x, FunctionsAre, true);
+                        if bSaveUnmasked
+                            tempIM2noMask = tempIM2noMask(:,:,:,WithinGroup);
+                            ComputeParametricImages(tempIM2noMask(:,:,:,NotOutliers),NameIM, x, FunctionsAre, false);
+                        end
+                    catch ME
+                        warning('Getting set didnt work');
+                        fprintf('%s\n',ME.message);
+                    end % try
+                end % iU=1:length(UniqueSet)
+            end % iSet=1:length(Sets2Check)
+        end % if bComputeSets
     end % for iSession=1:x.nSessions
     fprintf('\n');
     if UnAvailable>0
@@ -351,12 +432,18 @@ for iScanType=1:length(PreFixList)
     end
 end  % for iScanType=1:length(PreFixList)
 
+
 end
 
 
 %% ===================================================================================
 function ComputeParametricImages(IM, NameIM, x, FunctionsAre, bMask)
 %ComputeParametricImages Subfunction that computes the parametric images
+
+    if isempty(IM)
+        warning(['No valid images ' NameIM ' found, skipping']);
+        return;
+    end
 
     if bMask
         iDim = 2; % image data as column
@@ -383,15 +470,7 @@ function ComputeParametricImages(IM, NameIM, x, FunctionsAre, bMask)
         IM = IM(:,:,:,logical(UseIM));
     end
 
-    if isempty(IM)
-        warning(['No valid images ' NameIM ' found']);
-        if bMask
-            IM = zeros(sum(x.WBmask(:)),1);
-        else
-            IM = zeros(size(x.WBmask));
-        end
-    end
-    fprintf(['Computing & saving ' NameIM ' parametric images, ']);
+    fprintf(['Computing ' NameIM ' parametric map(s)...\n']);
 
     for iFunction=1:length(FunctionsAre{1})
         FunctionHandle = FunctionsAre{1}{iFunction};


### PR DESCRIPTION
## Following changes were implemented:
* Allow inputting the actual setsnames in *bCompute4Sets* that the user wants to create statistical maps of
* *b* prefix for all boolean parameters
* Make *IM2* more readable by renaming to *IM2noMasks*
* Add *bFlipHemispheres* section for recognizing *left right l r n/a NaN*, any combination of these _SetsOptions_ will be recognizes that those with _right_ should be flipped
* Improved behavior of _SetsOptions_ by redefining _UniqueSets_
* Shotcut/alias to _ExploreASL_Master_ with _ExploreASL_
* New input option 2 for loading dataset without processing

## Per review Jan Petr:
* Replaced continue by subfunctions or general bProceed variable
* cosmetic changes

## Linked tutorial:
Also check [this tutorial](https://docs.google.com/document/d/1-b272yYb6zyS4QoB1BciBs4-kuBS1PkmTi7LJ1MC1u0/edit?usp=sharing), which was created for the CICERO study.

This closes feature #27 