### PR TITLE
#63 AddOption x.S.bMasking

### DIFF
--- a/DataParTemplate.m
+++ b/DataParTemplate.m
@@ -229,7 +229,21 @@ function x = DataParTemplate(x)
 % 							   (OPTIONAL, DEFAULT = 0).
 % 							   - 1 = enabled
 % 							   - 0 = disabled
-
+%
+%% Masking parameters
+%   x.S.bMasking        - vector specifying if we should mask a ROI with a subject-specific mask
+%                       (1 = yes, 0 = no)
+%                       [1 0 0 0] = susceptibility mask (either population-or subject-wise)
+%                       [0 1 0 0] = vascular mask (only subject-wise)
+%                       [0 0 1 0] = subject-specific tissue-masking (e.g. pGM>0.5)
+%                       [0 0 0 1] = WholeBrain masking (used as memory compression)
+%                       [0 0 0 0] = no masking at all
+%                       [1 1 1 1] = apply all masks
+%                       Can also be used as boolean, where 
+%                       1 = [1 1 1 1]
+%                       0 = [0 0 0 0]
+%                       Can be useful for e.g. loading lesion masks outside the GM
+%                       (OPTIONAL, DEFAULT=1)
 
 x.name = ExampleDataSet;
 x.subject_regexp = '^Sub-\d{3}$';

--- a/Functions/xASL_init_VisualizationSettings.m
+++ b/Functions/xASL_init_VisualizationSettings.m
@@ -37,6 +37,14 @@ function [x] = xASL_init_VisualizationSettings(x)
         x.S = struct;
     end
 
+    if ~isfield(x.S,'bMasking') || isempty(x.S.bMasking)
+        x.S.bMasking = [1 1 1 1];
+    elseif isequal(x.S.bMasking, 1)
+        x.S.bMasking = [1 1 1 1];
+    elseif isequal(x.S.bMasking, 0)
+        x.S.bMasking = [0 0 0 0];        
+    end
+
     %% Slice numbers
     % Defines which transversal slices to use by default
     x.S.slices           = [53 62 74 87]; % for 1.5mm MNI, ([85 102 119 131] would be the same for 1mm MNI)
@@ -127,7 +135,12 @@ function [x] = xASL_init_VisualizationSettings(x)
         x.BILAT_FILTER = false;
     end
 
-    x.WBmask  = logical(xASL_io_Nifti2Im(fullfile(x.D.MapsSPMmodifiedDir,'WholeBrain.nii')));
+    ImageWB = xASL_io_Nifti2Im(fullfile(x.D.MapsSPMmodifiedDir,'WholeBrain.nii'));
+    if x.S.bMasking(4)==0
+        x.WBmask = true(size(ImageWB));
+    else
+        x.WBmask = logical(ImageWB);
+    end
 
     if ~isfield(x,'Quality') && isfield(x,'QUALITY')
         x.Quality = x.QUALITY; % backward compatibility


### PR DESCRIPTION
Added following options (see explanation in DataParTemplate.m):

* bSusceptibilityMask
* bVascularMask
* subject-wise bGMMask (e.g. the pGM>0.7)
* brainmasking when loading for lower memory usage.

Also added 

	"S" : {
	"bMasking" : 0
	}

to the TestDataSet.

Closes #63.