### PR TITLE
#90 Fixes #90

### DIFF
--- a/External/SPMmodified/xASL/xASL_io_Nifti2Im.m
+++ b/External/SPMmodified/xASL/xASL_io_Nifti2Im.m
@@ -136,17 +136,19 @@ end
 
 if exist('imOut', 'var')
 	MaxIm = max(imOut(isfinite(imOut)));
-	if MaxIm>1e9 && exist('Fpath', 'var') && exist('Ffile', 'var')
-		if ~isempty(regexp(Ffile, '^.*(T1|FLAIR).*$'))
-			warning('%s\n%s', 'Structural image with extremely high image intensities detected, resetting the maximum to 4096:', niftiIn);
-			imOut = imOut.*4096./MaxIm;
-		else
-			warning('%s\n%s', 'Extremely high image intensities detected, check if all processing and quantification went correctly:', niftiIn);
-			fprintf('This issue was seen before with erroneous interpretation of the Philips rescale slope\n');
-			fprintf('We only correct this automatically for T1/FLAIR images to avoid quantification issues\n');
-			fprintf('Hence for this image it is not automatically corrected\n');
-		end
-	end
+    if isempty(MaxIm)
+        % skip this image checking, it is empty
+    elseif MaxIm>1e9 && exist('Fpath', 'var') && exist('Ffile', 'var')
+        if ~isempty(regexp(Ffile, '^.*(T1|FLAIR).*$'))
+            warning('%s\n%s', 'Structural image with extremely high image intensities detected, resetting the maximum to 4096:', niftiIn);
+            imOut = imOut.*4096./MaxIm;
+        else
+            warning('%s\n%s', 'Extremely high image intensities detected, check if all processing and quantification went correctly:', niftiIn);
+            fprintf('This issue was seen before with erroneous interpretation of the Philips rescale slope\n');
+            fprintf('We only correct this automatically for T1/FLAIR images to avoid quantification issues\n');
+            fprintf('Hence for this image it is not automatically corrected\n');
+        end
+    end
 end
 
 


### PR DESCRIPTION
This is part of the xASL_io_Nifti2Im that loads an image and automatically checks if it needs to be scaled. But if the image is empty for whatever pipeline reason, it cannot find a maximum and crashed :) So this can be safely skipped.

I suggest putting this as hotfix in release 1.2.1.