### PR TITLE
Bug #99 loading metadata

### DIFF
--- a/Functions/xASL_init_LoadMetadata.m
+++ b/Functions/xASL_init_LoadMetadata.m
@@ -146,11 +146,7 @@ function [x] = xASL_init_LoadMetadata(x)
                     else % x.S.SetsID contains category number
                         % x.S.SetsOptions has the name of the category
                         if isfinite(x.S.SetsID(iSubjectSession,iSet))
-                            try
-                                VarData{iSubjectSession,3} = x.S.SetsOptions{iSet}{x.S.SetsID(iSubjectSession,iSet)};
-                            catch
-                                
-                            end
+                            VarData{iSubjectSession,3} = x.S.SetsOptions{iSet}{x.S.SetsID(iSubjectSession,iSet)};
                         else
                             VarData{iSubjectSession,3} = 'n/a';
                         end

--- a/Functions/xASL_str2num.m
+++ b/Functions/xASL_str2num.m
@@ -1,61 +1,96 @@
-function [DataOut] = xASL_str2num(DataIn)
+function [DataOut] = xASL_str2num(DataIn, bKeepCell, bReplaceNonNumerical)
 %xASL_str2num str2num wrapper, replacing 'n/a' with NaN (BIDS convention)
 % and converting only strings to numbers. Also allows inputting cells
 %
-% FORMAT:       [DataOut] = xASL_str2num(DataIn)
+% FORMAT: [DataOut] = xASL_str2num(DataIn)
 % 
-% INPUT:        ...
+% INPUT: DataIn - character, numerical or cell array
+%        bKeepCell - boolean specifying if cell array should be
+%                    preserved & strings inside the cell converted to numbers (TRUE),
+%                    or if the cell array should be converted to numerical (FALSE)
+%                    Note that this parameter will only be used if DataIn
+%                    was a cell array (otherwise forced to false)
+%                    (OPTIONAL, DEFAULT = FALSE)
+%        bReplaceNonNumerical - boolean specifying if a character or
+%                               cell without a number should be converted to NaN (TRUE) or
+%                               kept unchanged (FALSE). Note that this
+%                               parameter will only be used if bKeepCell is true
+%                               (OPTIONAL, DEFAULT = TRUE)
+%               
 %
-% OUTPUT:       ...
+% OUTPUT: DataOut   - converted numerical data
 % 
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% DESCRIPTION:  str2num wrapper, replacing 'n/a' with NaN (BIDS convention)
-%               and converting only strings to numbers. Also allows inputting cells.
-%
+% DESCRIPTION: str2num wrapper, which only converts strings to numbers, and allows inputting cells.
+%              Also, it replaces 'n/a' with NaN (BIDS convention). And it
+%              has some other functionality as described in bKeepCell &
+%              bReplaceNonNumerical above.
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% EXAMPLE:      ...
+% EXAMPLE: [5 6] = xASL_str2num('5 6')
+%          [5 6 NaN] = xASL_str2num({'5' '6' 'Weird'})
+%          {[5 6 NaN]} = xASL_str2num({'5' '6' 'Weird'}, 1)
+%          {[5 6 'Weird']} = xASL_str2num({'5' '6' 'Weird'}, 1, 0)
 % __________________________________
 % Copyright 2015-2020 ExploreASL
+
+
+%% -------------------------------------------------------
+%% Admin
+if nargin<2 || isempty(bKeepCell)
+    bKeepCell = false;
+elseif ~iscell(DataIn)
+    bKeepCell = false; % only keep cell if DataIn was cell
+end
+if nargin<3 || isempty(bReplaceNonNumerical)
+    bReplaceNonNumerical = true;
+elseif ~bKeepCell
+    bReplaceNonNumerical = true; % only keep original input for a cell
+end
 
 if isempty(DataIn)
 	DataOut = NaN;
 elseif ~iscell(DataIn)
-	DataOut = doConversion(DataIn);
+	DataOut = doConversion(DataIn, bKeepCell, bReplaceNonNumerical);
 else
-	% For cells - do it one by one
-	DataOut = zeros(size(DataIn));
-	for ii = 1:length(DataIn)
-		TempOut = doConversion(DataIn{ii});
-		if isnumeric(TempOut)
-			DataOut(ii) = TempOut;
-		else
-			DataOut(ii) = NaN;
-		end
-	end
+    DataOut = cellfun(@(y) doConversion(y, bKeepCell, bReplaceNonNumerical), DataIn);
 end
 
-return
 
-function DataOut = doConversion(DataIn)
+end
+
+    
+%% ==================================================================================
+function DataOut = doConversion(DataIn, bKeepCell, bReplaceNonNumerical)
+
+    
 if isempty(DataIn)
     DataOut = NaN;
 elseif ~isnumeric(DataIn)
-        try % if non-numeric data, that isn't NaN,
-            % then simply keep the data as is (if we cannot convert it)
-            if strcmp(DataIn,'n/a') || strcmp(DataIn,'NaN')
-                DataOut = NaN;
-            else
-                DataOut = str2num(DataIn);
-            end
-        catch
-            DataOut = DataIn;
+    try % if non-numeric data, that isn't NaN,
+        % then simply keep the data as is (if we cannot convert it)
+        if strcmp(DataIn,'n/a') || strcmp(DataIn,'NaN')
+            DataOut = NaN;
+        else
+            DataOut = str2num(DataIn);
         end
+    catch
+        DataOut = DataIn;
+    end
 else
     DataOut = DataIn;
 end
 
-if isempty(DataOut)
-    DataOut = NaN;
+if isempty(DataOut) || ~isnumeric(DataOut)
+    if bReplaceNonNumerical
+        DataOut = NaN;
+    else
+        DataOut = DataIn;
+    end
 end
 
-return
+if bKeepCell
+    DataOut = {DataOut};
+end
+
+
+end


### PR DESCRIPTION
## xASL_str2num
* Header added
* Allows converting strings inside a cell array to number array or keeping them in a cell array
* Allows choosing between resetting nonnumerical strings to NaN or keeping them (when keeping cells only)
* Other minor improvements

## xASL_init_LoadMetadata
* Allowing strings as well as numbers, make this flexible (& hopefully still readable :)
* avoid creating warnings for xASL specific MAT-files
* Cosmetic changes