### PR TITLE
Feature #112 output tc for asl2t1w

### DIFF
--- a/Functions/xASL_adm_LoadX.m
+++ b/Functions/xASL_adm_LoadX.m
@@ -1,10 +1,10 @@
 function [x, IsLoaded] = xASL_adm_LoadX(x, Path_xASL, bOverwrite)
 %xASL_adm_LoadX Load x.mat file that keeps track of QC output
-% FORMAT: [x[, IsLoaded]] = xASL_adm_LoadX(x, Path_xASL[, bOverwrite])
+% FORMAT: [x[, IsLoaded]] = xASL_adm_LoadX(x[, Path_xASL, bOverwrite])
 %
 % INPUT:
 %   x           - structure containing fields with all information required to run this submodule (REQUIRED)
-%   Path_xASL   - path to the x.mat that contains the QC output (REQUIRED)
+%   Path_xASL   - path to the x.mat that contains the QC output (OPTIONAL, DEFAULT = x.SUBJECTDIR/x.mat)
 %   bOverwrite  - true to overwrite the current x structure with the
 %                 x.Output & x.Output_im from the x.mat (OPTIONAL, DEFAULT=false)
 %
@@ -24,13 +24,21 @@ function [x, IsLoaded] = xASL_adm_LoadX(x, Path_xASL, bOverwrite)
 % EXAMPLE: [x, IsLoaded] = xASL_adm_LoadX(x, fullfile(x.D.ROOT,'x.mat'), true);
 %
 % __________________________________
-% Copyright (C) 2015-2019 ExploreASL
+% Copyright (C) 2015-2020 ExploreASL
 
 
 
 %% -------------------------------------
 %  Admin
 IsLoaded = false; % default
+
+if nargin<2 || isempty(Path_xASL)
+	if ~isfield(x,'SUBJECTDIR')
+		error('Path_xASL not provided and x.SUBJECTDIR not defined.');
+	end
+	Path_xASL = fullfile(x.SUBJECTDIR,'x.mat');
+end
+
 if nargin<3 || isempty(bOverwrite)
     bOverwrite = false;
 end

--- a/Functions/xASL_adm_SaveX.m
+++ b/Functions/xASL_adm_SaveX.m
@@ -1,11 +1,11 @@
 function xASL_adm_SaveX(x, Path_xASL, bOverwrite)
 %xASL_adm_SaveX Saves x.mat file that keeps track of QC output
-% FORMAT: xASL_adm_SaveX(x[, Path_xASL])
+% FORMAT: xASL_adm_SaveX(x[, Path_xASL, bOverwrite])
 %
 % INPUT:
 %   x           - structure containing fields with all information required to run this submodule (REQUIRED)
 %   Path_xASL   - path to the x.mat that contains the QC output (OPTIONAL, DEFAULT = x.SUBJECTDIR/x.mat)
-%   bOverwite   - boolean specifying if we overwrite
+%   bOverwite   - boolean specifying if we overwrite (OPTIONAL, DEFAULT = true)
 %
 % OUTPUT:
 %   n/a

--- a/Functions/xASL_adm_SaveX.m
+++ b/Functions/xASL_adm_SaveX.m
@@ -1,0 +1,34 @@
+function xASL_adm_SaveX(x, Path_xASL)
+%xASL_adm_SaveX Saves x.mat file that keeps track of QC output
+% FORMAT: xASL_adm_SaveX(x[, Path_xASL])
+%
+% INPUT:
+%   x           - structure containing fields with all information required to run this submodule (REQUIRED)
+%   Path_xASL   - path to the x.mat that contains the QC output (OPTIONAL, DEFAULT = x.SUBJECTDIR/x.mat)
+%
+% OUTPUT:
+%   n/a
+%
+% -----------------------------------------------------------------------------------------------------------------------------------------------------
+% DESCRIPTION: This function saves the x.mat either to the predefined path or the the subject x.mat
+%
+% EXAMPLE: xASL_adm_SaveX(x, fullfile(x.D.ROOT,'x.mat'));
+%
+% __________________________________
+% Copyright (C) 2015-2020 ExploreASL
+
+
+
+%% -------------------------------------
+%  Admin
+if nargin<2 || isempty(Path_xASL)
+	if ~isfield(x,'SUBJECTDIR')
+		error('Path_xASL not provided and x.SUBJECTDIR not defined.');
+	end
+	Path_xASL = fullfile(x.SUBJECTDIR,'x.mat');
+end
+
+xASL_delete(Path_xASL);
+save(Path_xASL,'x'); 
+
+end

--- a/Functions/xASL_adm_SaveX.m
+++ b/Functions/xASL_adm_SaveX.m
@@ -1,19 +1,20 @@
-function xASL_adm_SaveX(x, Path_xASL)
+function xASL_adm_SaveX(x, Path_xASL, bOverwrite)
 %xASL_adm_SaveX Saves x.mat file that keeps track of QC output
 % FORMAT: xASL_adm_SaveX(x[, Path_xASL])
 %
 % INPUT:
 %   x           - structure containing fields with all information required to run this submodule (REQUIRED)
 %   Path_xASL   - path to the x.mat that contains the QC output (OPTIONAL, DEFAULT = x.SUBJECTDIR/x.mat)
+%   bOverwite   - boolean specifying if we overwrite
 %
 % OUTPUT:
 %   n/a
-%
+
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % DESCRIPTION: This function saves the x.mat either to the predefined path or the the subject x.mat
 %
-% EXAMPLE: xASL_adm_SaveX(x, fullfile(x.D.ROOT,'x.mat'));
-%
+% EXAMPLE outside ExploreASL: xASL_adm_SaveX(x, fullfile(x.D.ROOT,'x.mat'));
+% EXAMPLE inside ExploreASL: xASL_adm_SaveX(x);
 % __________________________________
 % Copyright (C) 2015-2020 ExploreASL
 
@@ -27,8 +28,16 @@ if nargin<2 || isempty(Path_xASL)
 	end
 	Path_xASL = fullfile(x.SUBJECTDIR,'x.mat');
 end
+if nargin<3 || isempty(bOverwrite)
+    bOverwrite = true;
+end
 
-xASL_delete(Path_xASL);
-save(Path_xASL,'x'); 
+if exist(Path_xASL, 'file') && ~bOverwrite
+    error('x.mat already existed, skipping...');
+else
+    xASL_delete(Path_xASL);
+    save(Path_xASL,'x');
+end
+
 
 end

--- a/Modules/SubModule_ASL/xASL_wrp_RegisterASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_RegisterASL.m
@@ -516,10 +516,10 @@ if bRegistrationCBF
         fprintf('%s\n',['Iteration ' num2str(iT) ', Tanimoto coefficient = ' num2str(100*TanimotoPerc(iT),3) '%']);
     end
     fprintf('%s\n\n','--------------------------------------------------------------------');
-	
-	% Write the Tanimoto coefficient to the output QC structure
-	x.Output.ASL.TC_ASL2T1_Perc = TanimotoPerc(end);
 end
+
+% Write the Tanimoto coefficient to the output QC structure
+x.Output.ASL.TC_ASL2T1w_Perc = TanimotoPerc(end);
 
 %% ----------------------------------------------------------------------------------------
 %% Delete temporary files

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -51,8 +51,14 @@ x = xASL_adm_LoadX(x, PathX, true); % assume x.mat is newer than x
 if isfield(x,'Output_im') && isfield(x.Output_im,'ASL')
    x.Output_im = rmfield(x.Output_im,'ASL');
 end
+
 if isfield(x,'Output') && isfield(x.Output,'ASL')
-   x.Output = rmfield(x.Output,'ASL');
+	if isfield(x.Output.ASL,'TC_ASL2T1w_Perc')
+		xKeep.Output.ASL.TC_ASL2T1w_Perc = x.Output.ASL.TC_ASL2T1w_Perc;
+	else
+		xKeep = [];
+	end
+	x.Output = rmfield(x.Output,'ASL');
 end
 
 %% -----------------------------------------------------------------------------------
@@ -165,9 +171,17 @@ end
 %% 8) Summarize ASL orientation & check for left-right flips
 xASL_qc_PrintOrientation(x.SESSIONDIR, x.P.Path_ASL4D, x.SESSIONDIR, 'RigidRegASL');
 
+% Restore previously computed values
+if exist('xKeep','var')
+	fieldNamesList = fieldnames(xKeep.Output.ASL);
+	for iField = 1:length(fieldNamesList)
+		x.Output.ASL.(fieldNamesList{iField}) = xKeep.Output.ASL.(fieldNamesList{iField});
+	end
+end
 
 %% 9) Collect several other parameters & store all in PDF overview
 x = xASL_qc_CollectParameters(x, x.iSubject, 'ASL'); % Quick & Dirty solution, 0 == skip structural part
+
 xASL_delete(PathX);
 save(PathX,'x'); % future: do this in each xWrapper
 xASL_qc_CreatePDF(x, x.iSubject);

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -44,22 +44,8 @@ nVolumes = double(tempnii.hdr.dim(5));
 fprintf('%s\n','print visual quality assurance checks');
 Parms.ModuleName = 'ASL';
 close all % close all Figures to avoid capturing & saving the wrong Figure
-PathX = fullfile(x.SUBJECTDIR,'x.mat');
-x = xASL_adm_LoadX(x, PathX, true); % assume x.mat is newer than x
 
-% Clear any previous QC images
-if isfield(x,'Output_im') && isfield(x.Output_im,'ASL')
-   x.Output_im = rmfield(x.Output_im,'ASL');
-end
-
-if isfield(x,'Output') && isfield(x.Output,'ASL')
-	if isfield(x.Output.ASL,'TC_ASL2T1w_Perc')
-		xKeep.Output.ASL.TC_ASL2T1w_Perc = x.Output.ASL.TC_ASL2T1w_Perc;
-	else
-		xKeep = [];
-	end
-	x.Output = rmfield(x.Output,'ASL');
-end
+x = xASL_adm_LoadX(x, [], true); % assume x.mat is newer than x
 
 %% -----------------------------------------------------------------------------------
 %% 2) Make ASL NIfTIs ready for visualization & conversion to DICOM
@@ -171,19 +157,10 @@ end
 %% 8) Summarize ASL orientation & check for left-right flips
 xASL_qc_PrintOrientation(x.SESSIONDIR, x.P.Path_ASL4D, x.SESSIONDIR, 'RigidRegASL');
 
-% Restore previously computed values
-if exist('xKeep','var')
-	fieldNamesList = fieldnames(xKeep.Output.ASL);
-	for iField = 1:length(fieldNamesList)
-		x.Output.ASL.(fieldNamesList{iField}) = xKeep.Output.ASL.(fieldNamesList{iField});
-	end
-end
-
 %% 9) Collect several other parameters & store all in PDF overview
 x = xASL_qc_CollectParameters(x, x.iSubject, 'ASL'); % Quick & Dirty solution, 0 == skip structural part
 
-xASL_delete(PathX);
-save(PathX,'x'); % future: do this in each xWrapper
+xASL_adm_SaveX(x); % future: do this in each xWrapper
 xASL_qc_CreatePDF(x, x.iSubject);
 
 end

--- a/Modules/SubModule_Population/xASL_stat_GetRegistrationStatistics.m
+++ b/Modules/SubModule_Population/xASL_stat_GetRegistrationStatistics.m
@@ -1,5 +1,5 @@
 function xASL_stat_GetRegistrationStatistics(x)
-%xASL_stat_GetRegistrationStatistics Collect the Tanimoto Coefficients from registration in CSV file to check
+%xASL_stat_GetRegistrationStatistics Collect the Tanimoto Coefficients from registration in TSV file to check
 %
 % FORMAT: xASL_stat_GetRegistrationStatistics(x)
 % 
@@ -34,8 +34,11 @@ if nargin<1 || isempty(x)
     error('Missing the x-struct');
 end
 
+% Define a list of fields to write
 jsonFields = {'TC_ASL2T1w_Perc'};
 nFields = length(jsonFields);
+
+% Create the file name for TSV file to save
 PathTSV = fullfile(x.D.PopDir, 'Stats','RegistrationTC.tsv');
 
 % Print header
@@ -49,14 +52,17 @@ fprintf('%s\n','Loading & saving individual parameter files...  ');
 for iSubject=1:x.nSubjects
     for iSession=1:x.nSessions
 
-        % Track progress
+        % Joint index for subject and session
         iSubjSess = (iSubject-1)*x.nSessions+iSession;
+		
+		% Track progress
         xASL_TrackProgress(iSubjSess,x.nSubjectsSessions);        
         
-        % Default parameters
+        % Write the subject and session name in the TSV table
         TSV{1+iSubjSess,1} = x.SUBJECTS{iSubject};
         TSV{1+iSubjSess,2} = x.SESSIONS{iSession};
         
+		% Initialize with NaNs
         TSV(1+iSubjSess, 3:nFields+2) = repmat({NaN}, [1 nFields]);
         
         % Define path of the parameter file

--- a/Modules/SubModule_Population/xASL_stat_GetRegistrationStatistics.m
+++ b/Modules/SubModule_Population/xASL_stat_GetRegistrationStatistics.m
@@ -1,0 +1,86 @@
+function xASL_stat_GetRegistrationStatistics(x)
+%xASL_stat_GetRegistrationStatistics Collect the Tanimoto Coefficients from registration in CSV file to check
+%
+% FORMAT: xASL_stat_GetRegistrationStatistics(x)
+% 
+% INPUT:
+%   x - struct containing pipeline environment parameters (REQUIRED)
+%
+% INPUT FILES:
+%   The QC files for each subject
+%   '/MyStudy/SUBJECTDIR/QC_collection_SUBJECTDIR.json'
+%   Containing the calculated Tanimoto coefficients for registration between:
+%   - ASL-T1w: TC_ASL2T1w_Perc
+%
+% OUTPUT FILES: 
+%   Written to:
+%   /MyStudy/Population/Stats/RegistrationTC.tsv
+%                         
+% ------------------------------------------------------------------------------------------------
+% DESCRIPTION: Loads the data from the study given in the QC_collection*.json files. Goes through all subjects and 
+%              sessions and prints the Tanimoto coefficients that define the quality of the registrations.
+% steps:
+% 1. Load & extract parameters from individual parameter files
+% 2. Write TSV file
+% ------------------------------------------------------------------------------------------------
+% EXAMPLE: xASL_stat_GetRegistrationStatistics(x);
+% __________________________________
+% Copyright 2015-2020 ExploreASL
+
+
+%% -----------------------------------------------------------------------------------------------
+%% Admin
+if nargin<1 || isempty(x)
+    error('Missing the x-struct');
+end
+
+jsonFields = {'TC_ASL2T1w_Perc'};
+nFields = length(jsonFields);
+PathTSV = fullfile(x.D.PopDir, 'Stats','RegistrationTC.tsv');
+
+% Print header
+TSV = {'participant_id' 'session'};
+TSV(1,3:2+nFields) = jsonFields(1:nFields);
+
+%% -----------------------------------------------------------------------------------------------
+%% 1. Load & extract parameters from individual parameter files
+fprintf('%s\n','Loading & saving individual parameter files...  ');
+
+for iSubject=1:x.nSubjects
+    for iSession=1:x.nSessions
+
+        % Track progress
+        iSubjSess = (iSubject-1)*x.nSessions+iSession;
+        xASL_TrackProgress(iSubjSess,x.nSubjectsSessions);        
+        
+        % Default parameters
+        TSV{1+iSubjSess,1} = x.SUBJECTS{iSubject};
+        TSV{1+iSubjSess,2} = x.SESSIONS{iSession};
+        
+        TSV(1+iSubjSess, 3:nFields+2) = repmat({NaN}, [1 nFields]);
+        
+        % Define path of the parameter file
+		PathJSON = fullfile(x.D.ROOT, x.SUBJECTS{iSubject}, ['QC_collection_' x.SUBJECTS{iSubject} '.json']);
+
+		if exist(PathJSON, 'file')
+			% Load the file
+            Parms = xASL_import_json(PathJSON);
+            Parms = Parms.ASL;
+
+			% print all fields for subject_session into the TSV array
+			for iField=1:nFields
+				if isfield(Parms,jsonFields{iField}) && ~isempty(Parms.(jsonFields{iField}))
+					TSV{1+iSubjSess, 2+iField} = xASL_num2str(Parms.(jsonFields{iField}));
+				end
+			end
+		end
+    end
+end
+
+fprintf('\n');
+
+%% -----------------------------------------------------------------------------------------------
+%% 2. Write TSV file
+xASL_tsvWrite(TSV, PathTSV, 1);
+
+end

--- a/Modules/xASL_module_ASL.m
+++ b/Modules/xASL_module_ASL.m
@@ -264,7 +264,7 @@ end
 iState = 3;
 if ~x.mutex.HasState(StateName{iState})
 
-    xASL_wrp_RegisterASL(x);
+    x = xASL_wrp_RegisterASL(x);
 
     x.mutex.AddState(StateName{iState});
     xASL_adm_CompareDataSets([], [], x); % unit testing

--- a/Modules/xASL_module_ASL.m
+++ b/Modules/xASL_module_ASL.m
@@ -158,6 +158,21 @@ if ~x.mutex.HasState(StateName{3}) || ~x.mutex.HasState(StateName{4})
     % If we rerun the ASL module, then clean it fully for proper rerunning
     % This function cleans all ASL sessions, so only run this (once) for the first session
     xASL_adm_CleanUpBeforeRerun(x.D.ROOT, 2, false, false, x.P.SubjectID, x.P.SessionID);
+	
+	% Also clean the QC output files
+	x = xASL_adm_LoadX(x, [], true); % assume x.mat is newer than x
+
+	% Clear any previous QC images
+	if isfield(x,'Output_im') && isfield(x.Output_im,'ASL')
+		x.Output_im = rmfield(x.Output_im,'ASL');
+	end
+
+	if isfield(x,'Output') && isfield(x.Output,'ASL')
+		x.Output = rmfield(x.Output,'ASL');
+	end
+	
+	% And saved the cleaned up version
+	xASL_adm_SaveX(x);
 end
 
 if ~isfield(x,'motion_correction')
@@ -264,7 +279,13 @@ end
 iState = 3;
 if ~x.mutex.HasState(StateName{iState})
 
+	% Load the previously saved QC Output
+	x = xASL_adm_LoadX(x, [], true); % assume x.mat is newer than x
+
     x = xASL_wrp_RegisterASL(x);
+
+	% And saved the cleaned up version
+	xASL_adm_SaveX(x);
 
     x.mutex.AddState(StateName{iState});
     xASL_adm_CompareDataSets([], [], x); % unit testing


### PR DESCRIPTION
* Writing the Tanimoto coefficient for ASL2T1 registration to the x-struct and to the QC output.
* QC Output is cleaned at the start of the ASL module and not only in the QC submodule.
* Saving TC as registration statistics in the Population module

Close #112 