### PR TITLE
Feature #20 basil implementation

### DIFF
--- a/Functions/xASL_im_MaskNegativeVascularSignal.m
+++ b/Functions/xASL_im_MaskNegativeVascularSignal.m
@@ -1,20 +1,20 @@
-function [NegativeMask, TreatedCBF] = xASL_im_MaskNegativeVascularSignal(x, IsSpace)
+function [NegativeMask, TreatedPWI] = xASL_im_MaskNegativeVascularSignal(x, IsSpace)
 %xASL_im_MaskNegativeVascularSignal Segment ASL image clusters with
 %significantly negative signal
 %
-% FORMAT: [NegativeMask, TreatedCBF] = xASL_quant_DetectNegativeVascularSignal(x)
+% FORMAT: [NegativeMask, TreatedPWI] = xASL_quant_DetectNegativeVascularSignal(x)
 %
 % INPUT:
 %   x                   - struct containing pipeline environment parameters, useful when only initializing ExploreASL/debugging (REQUIRED)
-%   x.P.Path_CBF        - path to CBF image
-% & x.P.Pop_Path_qCBF
+%   x.P.Path_PWI        - path to PWI image
+% & x.P.Pop_Path_PWI
 %   x.P.Path_c1T1       - path to GM segmentation map
 % & x.P.Pop_Path_rc1T1
 %   IsSpace             - 1 for native ASL space, 2 for standard space (REQUIRED)
 %
 % OUTPUT:
 %   NegativeMask    - Binary mask with 1 for negative signal
-%   TreatedCBF      - Original CBF image, with negative vascular clusters interpolated
+%   TreatedPWI      - Original PWI image, with negative vascular clusters interpolated
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % DESCRIPTION: This function segments clusters with significant negative
 %              ASL signal. This can be tricky as there is also the negative tail of Gaussian noise
@@ -27,108 +27,114 @@ function [NegativeMask, TreatedCBF] = xASL_im_MaskNegativeVascularSignal(x, IsSp
 %              this as well.
 %              The procedure works as follows:
 %
-%              1) Obtain mask of negative voxels within pGM>0.5 mask
-%              2) Obtain distribution of subzero clusters
-%              3) Define the negative threshold
-%              4) Create mask by thresholding whole image
+%              1. Obtain mask of negative voxels within pGM>0.5 mask
+%              2. Obtain distribution of subzero clusters
+%              3. Define the negative threshold
+%              4. Create mask by thresholding whole image
 %
 %              Note that the definition of the threshold is obtained within
-%              the GM only, but that this threshold is applied to the full image
+%              the GM only, but that this threshold is applied to the full image.
+%
+%              Note that instead of the PWI path input, a CBF image should
+%              work equally well, as we don't expect a smooth M0 biasfield
+%              to change the distribution of negative clusters
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % EXAMPLE: NegativeMask = xASL_im_MaskNegativeVascularSignal(x);
 % __________________________________
-% Copyright 2015-2019 ExploreASL
-
+% Copyright 2015-2020 ExploreASL
+ 
     if nargin<2 || isempty(IsSpace)
         warning('Didnt know space to calculate negative mask in, skipping');
         return;
     end
-
+ 
     fprintf('%s\n','Detecting vascular clusters with negative ASL signal:...');
-
+ 
     if IsSpace==1 % native space
-        CBFpath = x.P.Path_CBF;
+        PWIpath = x.P.Path_PWI;
         GMpath = x.P.Path_PVgm;
     elseif IsSpace==2 % standard space
-        CBFpath = x.P.Pop_Path_qCBF;
+        PWIpath = x.P.Pop_Path_PWI;
         GMpath = x.P.Pop_Path_rc1T1;
         % no need to reslice
     end
     
-    if ~xASL_exist(CBFpath, 'file')
-        warning([CBFpath ' missing, skipping']);
+    if ~xASL_exist(PWIpath, 'file')
+        warning([PWIpath ' missing, skipping']);
         return;
     elseif ~xASL_exist(GMpath, 'file')
         warning([GMpath ' missing, skipping']);
         return;
     end
         
-
-    %% 1) Obtain mask of negative voxels within pGM>0.5 mask
+ 
+    %% 1. Obtain mask of negative voxels within pGM>0.5 mask
     % Create GMmask in ASL space from SPM
-    CBFim = xASL_io_Nifti2Im(CBFpath);
-    if size(CBFim,4)>1
-        CBFim = xASL_stat_MeanNan(CBFim,4);
+    PWIim = xASL_io_Nifti2Im(PWIpath);
+    if size(PWIim,4)>1
+        PWIim = xASL_stat_MeanNan(PWIim,4);
     end
     GMmask = xASL_io_Nifti2Im(GMpath)>0.5;
     
-    if ~isequal(size(CBFim),size(GMmask))
-        warning('Sizes of CBF and GM images differed');
+    if ~isequal(size(PWIim),size(GMmask))
+        warning('Sizes of PWI and GM images differed');
     end
     
-    NegativeMask = CBFim<0 & GMmask;
-
+    NegativeMask = PWIim<0 & GMmask;
+ 
     if IsSpace==2
         % dilate to connect neighboring labels
         NegativeLabels = xASL_im_DilateErodeFull(NegativeMask,'dilate',xASL_im_DilateErodeSphere(2));
     else
         NegativeLabels = NegativeMask;
     end
-
+ 
     if sum(NegativeMask(:))>0 % if there are subzero voxels
-
-        %% 2) Obtain distribution of subzero clusters
+ 
+        %% 2. Obtain distribution of subzero clusters
         % Label (i.e. assign a number) to each subzero clusters
         labeled = single(spm_bwlabel(double(NegativeLabels),26));
 %         labeled = xASL_im_DilateErodeFull(labeled,'dilate',xASL_im_DilateErodeSphere(1));
         % 26 = corner criterion for connectivity (being strict in the definition of "clusters")
-
+ 
         % mask labels with NegativeMask again
         labeled(~NegativeMask) = 0;
-
+ 
         % Get the mean value of each subzero clusters
         for iP=1:max(labeled(:))
             xASL_TrackProgress(iP, max(labeled(:)));
-            MeanValue(iP) = mean(CBFim(labeled==iP));
+            MeanValue(iP) = mean(PWIim(labeled==iP));
         end
-
-        %% 3) Define the negative threshold
+ 
+        %% 3. Define the negative threshold
         medianValue = xASL_stat_MedianNan(MeanValue);
         madValue = xASL_stat_MadNan(MeanValue,1);
         ClipThr = medianValue - (4*madValue);
-
+ 
 %         [N, X] = hist(MeanValue);
 %         N = N./sum(N(:));
 %         figure(1);plot(X, N)
-
+ 
     else
-        ClipThr = -max(CBFim(:)); % don't clip
+        ClipThr = -max(PWIim(:)); % don't clip
     end
-
+ 
     fprintf('\b');
     xASL_TrackProgress(0.5,1);
-
-    %% 4) Create mask by thresholding whole image
-    TreatedCBF = CBFim;
-    NegativeMask = TreatedCBF<ClipThr;
+ 
+    %% 4. Create mask by thresholding whole image
+    TreatedPWI = PWIim;
+    NegativeMask = TreatedPWI<ClipThr;
 %     NegativeMask = xASL_im_DilateErodeFull(NegativeMask,'dilate',xASL_im_DilateErodeSphere(1));
-    TreatedCBF(NegativeMask) = NaN;
-
+    TreatedPWI(NegativeMask) = NaN;
+ 
     if nargout>1
         xASL_TrackProgress(0.75,1);
-        TreatedCBF = xASL_im_ndnanfilter(TreatedCBF,'gauss', [8 8 8], 2); % extrapolation only
+        TreatedPWI = xASL_im_ndnanfilter(TreatedPWI,'gauss', [8 8 8], 2); % extrapolation only
     end
-
+ 
     xASL_TrackProgress(1,1);
     fprintf('\n');
+    
+    
 end

--- a/Functions/xASL_im_MaskPeakVascularSignal.m
+++ b/Functions/xASL_im_MaskPeakVascularSignal.m
@@ -1,12 +1,12 @@
-function [MaskIM, TreatedCBF] = xASL_im_MaskPeakVascularSignal(PathCBF, Path_M0, bClip, ClipThresholdValue, CompressionRate)
+function [MaskIM, TreatedCBF] = xASL_im_MaskPeakVascularSignal(PathPWI, Path_M0, bClip, ClipThresholdValue, CompressionRate)
 %xASL_im_MaskPeakVascularSignal Detect voxels with high intra-vascular peak
 %ASL signal
 %
-% FORMAT: [MaskIM, CBF] = xASL_quant_VascularContrast(PathCBF, Path_M0, CompressionRate, ClipThresholdValue, bClip)
+% FORMAT: [MaskIM, CBF] = xASL_quant_VascularContrast(PathPWI, Path_M0, CompressionRate, ClipThresholdValue, bClip)
 %
 % INPUT:
-%   PathCBF             - path to CBF image (REQUIRED)
-%   Path_M0             - path to M0 image (OPTIONAL)
+%   PathPWI             - path to PWI image or image matrix (REQUIRED)
+%   Path_M0             - path to M0 image or image matrix (OPTIONAL)
 %   bClip               - true for applying compression/clipping of the
 %                         intra-vascular detected voxels (OPTIONAL, DEFAULT=false)
 %   ClipThresholdValue  - how many Mean Absolute Difference (MAD) above the
@@ -17,7 +17,7 @@ function [MaskIM, TreatedCBF] = xASL_im_MaskPeakVascularSignal(PathCBF, Path_M0,
 %
 % OUTPUT:
 %   MaskIM              - Binary mask with 1 for negative signal
-%   TreatedCBF          - Original CBF image, with extremely high vascular
+%   TreatedCBF          - CBF image, with extremely high vascular
 %                         signal compressed
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % DESCRIPTION: This function searches for an acceptable high
@@ -39,6 +39,10 @@ function [MaskIM, TreatedCBF] = xASL_im_MaskPeakVascularSignal(PathCBF, Path_M0,
 %              Note that the definition of the threshold is obtained within
 %              the GM only, but that this threshold is applied to the full
 %              image to also remove extracranial extreme values.
+%
+%              Note that the performance may change when using this script
+%              with or without M0, as this will change the distribution
+%              that determines where the threshold for extremes lies.
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % EXAMPLE: MaskIM = xASL_im_MaskPeakVascularSignal('/analysis/Sub-001/ASL_1/CBF.nii','/analysis/Sub-001/ASL_1/rM0.nii');
 % __________________________________
@@ -50,12 +54,12 @@ function [MaskIM, TreatedCBF] = xASL_im_MaskPeakVascularSignal(PathCBF, Path_M0,
 %% ===================================================================
 % Admin
 
-if nargin<1 || isempty(PathCBF)
+if nargin<1 || isempty(PathPWI)
     warning('No CBF image found, skipping...');
     return;
 else
-    TreatedCBF = xASL_io_Nifti2Im(PathCBF);
-    if sum(isfinite(TreatedCBF(:)))==0
+    PWI = xASL_io_Nifti2Im(PathPWI); % allow both a path or image matrix
+    if sum(isfinite(PWI(:)))==0
         warning('Empty CBF image, skipping...');
         return;
     end
@@ -69,8 +73,8 @@ else
 		warning('No usable M0 image, using CBF only');
 		M0_im = 1;
 	else
-		M0_im = xASL_io_Nifti2Im(Path_M0);
-		if ~(min(size(TreatedCBF)==size(M0_im))) % if CBF & M0 images arent the same size (which is why rM0 should be the input path in case of different sizes)
+		M0_im = xASL_io_Nifti2Im(Path_M0); % allow both a path or image matrix
+		if ~(min(size(PWI)==size(M0_im))) % if CBF & M0 images arent the same size (which is why rM0 should be the input path in case of different sizes)
 			warning('M0 & CBF images differed in size, using CBF image only');
 			M0_im = 1;
 		elseif xASL_stat_SumNan(M0_im(:))==0
@@ -91,14 +95,17 @@ if nargin<5 || isempty(CompressionRate)
 end
 
 
-%% 1) Segment GM on ASL image at 80th percentile of CBF image distribution
-DataSort = sort(TreatedCBF(isfinite(TreatedCBF)));
-IndexN = round(0.8*length(DataSort));
-GMmask = TreatedCBF>DataSort(IndexN) & isfinite(TreatedCBF);
 
-%% 2) For PWI & CBF images, select voxels higher than median + ClipThresholdValue MAD
-% Create PWI & PWI/M0 image
-TempCBF{1} = TreatedCBF.*M0_im; % PWI
+%% 1. Segment GM on ASL image at 80th percentile of PWI image distribution
+DataSort = sort(PWI(isfinite(PWI)));
+IndexN = round(0.8*length(DataSort));
+GMmask = PWI>DataSort(IndexN) & isfinite(PWI);
+
+
+%% 2. For PWI & CBF images, select voxels higher than median + ClipThresholdValue MAD
+% Create CBF image et al
+TreatedCBF = PWI./M0_im;
+TempCBF{1} = PWI; % PWI
 TempCBF{2} = TreatedCBF; % CBF (PWI/M0)
 
 % Get masks for both PWI & CBF images (i.e. with & without M0 division
@@ -110,10 +117,10 @@ for ii=1:2
     MaskIM{ii} = TempCBF{ii}>ClipThr(ii);
 end
 
-%% 3) Combine the two created masks
+%% 3. Combine the two created masks
 MaskIM = MaskIM{1} & MaskIM{2};
 
-%% 4) Obtain average clipping value from selected voxels from the combined masks
+%% 4. Obtain average clipping value from selected voxels from the combined masks
 % We compress after M0 correction, otherwise we could still have very high values
 ClipThr = xASL_stat_MedianNan(TreatedCBF(MaskIM));
 MaskIM = TreatedCBF>ClipThr; % create new Mask

--- a/Functions/xASL_qc_temporalSNR.m
+++ b/Functions/xASL_qc_temporalSNR.m
@@ -33,7 +33,7 @@ function tSNR = xASL_qc_temporalSNR(pathIm4D,pathImTissueProb)
 %                 hardware and acquisition choices ??? Implications for controlling false positive rates. NeuroImage, 154,15-22
 %              4) SPM Utility + toolbox. Cyril Pernet. https://osf.io/wn3h8/
 %
-% EXAMPLE: tSNR = xASL_qc_temporalSNR(x.P.Path_PWI4D,{x.P.Path_PVgm x.P.Path_PVwm});
+% EXAMPLE: tSNR = xASL_qc_temporalSNR(x.P.Path_PWI,{x.P.Path_PVgm x.P.Path_PVwm});
 % __________________________________
 % Copyright (C) 2015-2019 ExploreASL
 

--- a/Modules/SubModule_ASL/xASL_wrp_Quantify.m
+++ b/Modules/SubModule_ASL/xASL_wrp_Quantify.m
@@ -76,6 +76,7 @@ fprintf('%s\n','Loading PWI & M0 images');
 
 % Load ASL PWI
 PWI = xASL_io_Nifti2Im(PWI_Path); % Load CBF nifti
+PWI = xASL_stat_MeanNan(PWI, 4); % average timeseries
 ASL_parms = xASL_adm_LoadParms(x.P.Path_ASL4D_parms_mat, x);
 
 if xASL_stat_SumNan(PWI(:))==0

--- a/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
@@ -194,7 +194,7 @@ if dim4>1 && round(dim4/2)==dim4/2 && dim4==nVolumes
     % do a paired subtraction
     [ControlIm, LabelIm] = xASL_quant_GetControlLabelOrder(ASL_im);
     ASL_im = ControlIm - LabelIm;
-    xASL_io_SaveNifti(x.P.Path_temp_despiked_ASL4D, x.P.Path_PWI, xASL_stat_MeanNan(ASL_im, 4), [], false);
+    xASL_io_SaveNifti(x.P.Path_temp_despiked_ASL4D, x.P.Path_PWI, ASL_im, [], false);
 
     if x.SavePWI4D % option to store subtracted time-series (PWI4D)
         xASL_io_SaveNifti(x.P.Path_temp_despiked_ASL4D, x.P.Path_PWI4D, ASL_im, 32, false);
@@ -225,7 +225,7 @@ end
 
 %% ------------------------------------------------------------------------------------------
 % 6    Save PWI NIfTI & time-series-related maps (SD, SNR)
-PWI = xASL_stat_MeanNan(ASL_im,4);
+PWI = ASL_im;
 MaskIM = xASL_io_Nifti2Im(fullfile(x.D.MapsSPMmodifiedDir, 'rgrey.nii'));
 MaskIM = MaskIM>(0.7*max(MaskIM(:)));
 

--- a/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
@@ -47,10 +47,6 @@ end
 tempnii = xASL_io_ReadNifti(x.P.Path_despiked_ASL4D);
 nVolumes = double(tempnii.hdr.dim(5));
 
-if ~isfield(x,'SavePWI4D')
-    x.SavePWI4D   = 0;
-end
-
 xASL_im_CreateASLDeformationField(x); % make sure we have the deformation field in ASL resolution
 
 %% TopUp files
@@ -195,11 +191,6 @@ if dim4>1 && round(dim4/2)==dim4/2 && dim4==nVolumes
     [ControlIm, LabelIm] = xASL_quant_GetControlLabelOrder(ASL_im);
     ASL_im = ControlIm - LabelIm;
     xASL_io_SaveNifti(x.P.Path_temp_despiked_ASL4D, x.P.Path_PWI, ASL_im, [], false);
-
-    if x.SavePWI4D % option to store subtracted time-series (PWI4D)
-        xASL_io_SaveNifti(x.P.Path_temp_despiked_ASL4D, x.P.Path_PWI4D, ASL_im, 32, false);
-        xASL_spm_reslice(x.P.Path_PWI, x.P.Path_PWI4D, [], [], x.Quality, x.P.Path_PWI4D);
-    end
 elseif dim4 == 1
     xASL_io_SaveNifti(x.P.Path_temp_despiked_ASL4D, x.P.Path_PWI, ASL_im, [], false);
 end
@@ -216,10 +207,6 @@ if dim4>1 && round(dim4/2)==dim4/2 && dim4==nVolumes
     % do a paired subtraction
     [ControlIm, LabelIm] = xASL_quant_GetControlLabelOrder(ASL_im);
     ASL_im = ControlIm - LabelIm;
-
-    if x.SavePWI4D % option to store subtracted time-series (PWI4D)
-        xASL_io_SaveNifti(x.P.Path_rtemp_despiked_ASL4D, x.P.Pop_Path_PWI4D, ASL_im,32, false);
-    end
 end
 
 

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -145,9 +145,7 @@ if nVolumes>10
             end
         end
 
-        if ~ExistPWI4D
-            xASL_delete(x.P.Path_PWI4D);
-        end
+        xASL_delete(x.P.Path_PWI4D);
     else
         warning('Skipping SPM UP QC because structural files didnt exist');
     end

--- a/Modules/xASL_module_ASL.m
+++ b/Modules/xASL_module_ASL.m
@@ -392,28 +392,26 @@ if ~x.mutex.HasState(StateName{iState}) && x.mutex.HasState(StateName{iState-4})
         warning(['Skipped standard space quantification: ' x.P.Pop_Path_PWI ' missing']);
     else
         xASL_wrp_Quantify(x);
+        
+        if x.SavePWI4D        
+            fprintf('%s\n','Quantifying ASL timeseries in standard space');
+            xASL_wrp_Quantify(x, x.P.Pop_Path_PWI, x.P.Pop_Path_qCBF4D);
+        end
     end
     % Quantification in native space:
     if ~xASL_exist(x.P.Path_PWI,'file')
         warning('Skipped native space quantification: files missing');
     else
         xASL_wrp_Quantify(x, x.P.Path_PWI, x.P.Path_CBF, x.P.Path_rM0, x.P.Path_SliceGradient);
-    end
-
-    % allow 4D quantification as well
-    if x.SavePWI4D
-        if ~xASL_exist(x.P.Path_PWI4D,'file')
-            fprintf('%s\n','Skipping, native space PWI4D missing');
-        else
+        
+        if x.SavePWI4D
             fprintf('%s\n','Quantifying ASL timeseries in native space');
-            xASL_wrp_Quantify(x, x.P.Path_PWI4D, x.P.Path_qCBF4D, x.P.Path_rM0, x.P.Path_SliceGradient);
-        end
-        if ~xASL_exist(x.P.Pop_Path_PWI4D,'file')
-            fprintf('%s\n','Skipping, standard space PWI4D missing');
-        else
-            fprintf('%s\n','Quantifying ASL timeseries in standard space');
-            xASL_wrp_Quantify(x, x.P.Pop_Path_PWI4D, x.P.Pop_Path_qCBF4D);
-        end
+            xASL_wrp_Quantify(x, x.P.Path_PWI, x.P.Path_qCBF4D, x.P.Path_rM0, x.P.Path_SliceGradient);        
+        end        
+    end
+    
+    if x.DELETETEMP
+        xASL_delete(x.P.Path_PWI);
     end
 
     x.mutex.AddState(StateName{iState});

--- a/Modules/xASL_module_ASL.m
+++ b/Modules/xASL_module_ASL.m
@@ -24,14 +24,14 @@ function [result, x] = xASL_module_ASL(x)
 % 040_ResliceASL        - Resample ASL images to standard space
 % 050_PreparePV         - Create partial volume images in ASL space with ASL resolution
 % 060_ProcessM0         - M0 image processing
-% 070_Quantification    - CBF quantification
-% 080_CreateAnalysisMask- Create mask using FoV, vascular outliers & susceptibility atlas
+% 070_CreateAnalysisMask- Create mask using FoV, vascular outliers & susceptibility atlas
+% 080_Quantification    - CBF quantification
 % 090_VisualQC_ASL      - Generate QC parameters & images
 % 100_WADQC             - QC for WAD-QC DICOM server (OPTIONAL)
 %
 % EXAMPLE: [~, x] = xASL_module_ASL(x);
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% Copyright 2015-2019 ExploreASL
+% Copyright 2015-2020 ExploreASL
 
 
 %% Admin
@@ -147,8 +147,8 @@ StateName{ 3} = '030_RegisterASL';
 StateName{ 4} = '040_ResampleASL';
 StateName{ 5} = '050_PreparePV';
 StateName{ 6} = '060_ProcessM0';
-StateName{ 7} = '070_Quantification';
-StateName{ 8} = '080_CreateAnalysisMask';
+StateName{ 7} = '070_CreateAnalysisMask';
+StateName{ 8} = '080_Quantification';
 StateName{ 9} = '090_VisualQC_ASL';
 StateName{10} = '100_WADQC';
 
@@ -353,10 +353,37 @@ end
 
 
 %% -----------------------------------------------------------------------------
-%% 7    Quantification
-% Quantification is performed here according to ASL consensus paper (Alsop, MRM 2016)
+%% 7    Create analysis mask
 iState = 7;
-if ~x.mutex.HasState(StateName{iState}) && x.mutex.HasState(StateName{iState-3})
+x.P.Path_MaskVascular = fullfile(x.SESSIONDIR, 'MaskVascular.nii');
+x.P.Pop_Path_MaskVascular = fullfile(x.D.PopDir, ['MaskVascular_' x.P.SubjectID '_' x.P.SessionID '.nii']);
+x.PathPop_MaskSusceptibility = fullfile(x.D.PopDir, ['rMaskSusceptibility_' x.P.SubjectID '_' x.P.SessionID '.nii']);
+
+if ~x.mutex.HasState(StateName{iState})
+    if xASL_exist(x.P.Path_c1T1,'file') && xASL_exist(x.P.Path_c2T1,'file')
+        if size(xASL_io_Nifti2Im(x.P.Path_PWI),4)>1
+            warning('Skipped vascular masking because we had too many images');
+		else
+            xASL_wrp_CreateAnalysisMask(x);
+
+            x.mutex.AddState(StateName{iState});
+            xASL_adm_CompareDataSets([], [], x); % unit testing
+        end
+    else
+        if  bO;fprintf('%s\n',['T1w-related images missing, skipping ' StateName{iState}]);end
+    end
+else
+    xASL_adm_CompareDataSets([], [], x,2,StateName{iState}); % unit testing - only evaluation
+    if  bO;fprintf('%s\n',[StateName{iState} ' has already been performed, skipping...']);end
+end
+
+
+
+%% -----------------------------------------------------------------------------
+%% 8    Quantification
+% Quantification is performed here according to ASL consensus paper (Alsop, MRM 2016)
+iState = 8;
+if ~x.mutex.HasState(StateName{iState}) && x.mutex.HasState(StateName{iState-4})
 
     fprintf('%s\n','Quantifying ASL:   ');
 
@@ -396,33 +423,6 @@ if ~x.mutex.HasState(StateName{iState}) && x.mutex.HasState(StateName{iState-3})
 else
 	xASL_adm_CompareDataSets([], [], x,2,StateName{iState}); % unit testing - only evaluation
 	if  bO; fprintf('%s\n',[StateName{iState} ' has already been performed, skipping...']); end
-end
-
-
-%% -----------------------------------------------------------------------------
-%% 8    Create analysis mask
-iState = 8;
-x.P.Pop_Path_CBF_Masked = fullfile(x.D.PopDir, ['qCBF_masked_' x.P.SubjectID '_' x.P.SessionID '.nii']);
-x.P.Path_MaskVascular = fullfile(x.SESSIONDIR, 'MaskVascular.nii');
-x.P.Pop_Path_MaskVascular = fullfile(x.D.PopDir, ['MaskVascular_' x.P.SubjectID '_' x.P.SessionID '.nii']);
-x.PathPop_MaskSusceptibility = fullfile(x.D.PopDir, ['rMaskSusceptibility_' x.P.SubjectID '_' x.P.SessionID '.nii']);
-
-if ~x.mutex.HasState(StateName{iState})
-    if xASL_exist(x.P.Path_c1T1,'file') && xASL_exist(x.P.Path_c2T1,'file')
-        if size(xASL_io_Nifti2Im(x.P.Path_CBF),4)>1
-            warning('Skipped vascular masking because we had too many images');
-		else
-            xASL_wrp_CreateAnalysisMask(x);
-
-            x.mutex.AddState(StateName{iState});
-            xASL_adm_CompareDataSets([], [], x); % unit testing
-        end
-    else
-        if  bO;fprintf('%s\n',['T1w-related images missing, skipping ' StateName{iState}]);end
-    end
-else
-    xASL_adm_CompareDataSets([], [], x,2,StateName{iState}); % unit testing - only evaluation
-    if  bO;fprintf('%s\n',[StateName{iState} ' has already been performed, skipping...']);end
 end
 
 


### PR DESCRIPTION
* Still need to test this
* Still need to implement changes from hotfix1.2.1
* Otherwise this should be good to implement BASIL

The following steps were applied:
## The following steps are needed as pre-work for BASIL
1. BASIL prefers masks to limit the voxels on which to run the modeling, but ExploreASL currently masks after the quantification. The masking wrapper should therefore be moved to before the quantification wrapper
    1. CBF will be replaced by PWI in the xASL_wrp_CreateAnalysisMask, after which this part can be moved in front of the Quantification
2. For better modeling BASIL requires the full 4D timeseries. Currently the resample wrapper does the averaging, unless there is a PWI4D option that states to keep the 4D timeseries. Instead, the averaging should move from the resample wrapper to the quantification wrapper, to ensure that the quantification wrapper always has access to the full 4D timeseries. The control-label subtraction can stay in the resample wrapper. The PWI4D flag can stay, but would be applied in the quantification wrapper only, where it would disable deleting of the temporary time series (this is for advanced users that want to keep the 4D time series for modelling purposes).
    1. Keep subtraction in xASL_wrp_Resample
    2. Move averaging to xASL_wrp_Quantify
    3. Remove PWI4D option from xASL_wrp_Resample
    4. Keep PWI4D option in xASL_wrp_Quantify


