### PR TITLE
#182 WM overlay for QC with contours and template WM.

### DIFF
--- a/DataParTemplate.m
+++ b/DataParTemplate.m
@@ -301,10 +301,10 @@ function x = DataParTemplate(x)
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % VISUALIZATION PARAMETERS
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% x.bVisualQCCBFvsGMWMTemplate - if == 1, uses the template GM and WM to make visualization overlays with CBF and other derived maps
+% x.vis.bVisualQCCBFvsGMWMTemplate - if == 1, uses the template GM and WM to make visualization overlays with CBF and other derived maps
 %                              if == 0, uses the individual GM and WM maps of the subject to make visualizations
 %                              (OPTIONAL, DEFAULT = 0)
-% x.bVisualQCCBFvsGMWMContour -  if == 1, then produces the GM and WM as a contour in the overlay with CBF and derived maps, not a full ROI - 1 pixel thickness (contour calculated per slice basis).
+% x.vis.bVisualQCCBFvsGMWMContour -  if == 1, then produces the GM and WM as a contour in the overlay with CBF and derived maps, not a full ROI - 1 pixel thickness (contour calculated per slice basis).
 %                              if == 0, then a standard full GM or WM ROI is used
 %                              (OPTIONAL, DEFAULT = 0)
 %   x.S.bMasking        - vector specifying if we should mask a ROI with a subject-specific mask

--- a/DataParTemplate.m
+++ b/DataParTemplate.m
@@ -304,7 +304,7 @@ function x = DataParTemplate(x)
 % x.bVisualQCCBFvsGMWMTemplate - if == 1, uses the template GM and WM to make visualization overlays with CBF and other derived maps
 %                              if == 0, uses the individual GM and WM maps of the subject to make visualizations
 %                              (OPTIONAL, DEFAULT = 0)
-% x.bVisualQCCBFvsGMWMContour -  if == 1, then produces the WM and GM as a contour in the overlay with CBF and derived maps, not a full ROI - 1 pixel thickness (contour calculated per slice basis).
+% x.bVisualQCCBFvsGMWMContour -  if == 1, then produces the GM and WM as a contour in the overlay with CBF and derived maps, not a full ROI - 1 pixel thickness (contour calculated per slice basis).
 %                              if == 0, then a standard full GM or WM ROI is used
 %                              (OPTIONAL, DEFAULT = 0)
 %   x.S.bMasking        - vector specifying if we should mask a ROI with a subject-specific mask

--- a/DataParTemplate.m
+++ b/DataParTemplate.m
@@ -34,8 +34,12 @@ function x = DataParTemplate(x)
 %                             if disabled, this function will try to use the system-initialized FSL 
 %                             and throw an error if FSL is not initialized
 %                             (OPTIONAL, DEFAULT = disabled)
-% x.MakeNIfTI4DICOM - Boolean to output CBF native space maps resampled and/or registered to the original T1w/ASL, and contrast adapted and in 12 bit
-% 					  range allowing to convert the NIfTI to a DICOM file, e.g. for implementation in PACS or other DICOM archives
+% x.MakeNIfTI4DICOM - if set to true, an additional CBF image will be
+%                     created with modifications that allow it to be easily
+%                     implemented back into a DICOM for e.g. PACS:
+%                     1. Remove peak & valley signal, remove NaNs, rescale
+%                     to 12 bit integers, apply original orientation
+%                     (2 copies saved, with original ASL and T1w orientation)
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % STUDY PARAMETERS
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
@@ -294,17 +298,16 @@ function x = DataParTemplate(x)
 %                    - 1 = enabled, use Gaussian kernel with FWHM in mm given in PVCNativeSpaceKernel
 %                    - 0 = disabled, use 'flat' kernel with voxels given in PVCNativeSpaceKernel
 %
-% x.MakeNIfTI4DICOM - if set to true, an additional CBF image will be
-%                     created with modifications that allow it to be easily
-%                     implemented back into a DICOM for e.g. PACS:
-%                     1. Remove peak & valley signal, remove NaNs, rescale
-%                     to 12 bit integers, apply original orientation
-%                     (2 copies saved, with original ASL and T1w orientation)
-%
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% MASKING & ATLAS PARAMETERS
+% VISUALIZATION PARAMETERS
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% x.S.bMasking        - vector specifying if we should mask a ROI with a subject-specific mask
+% x.bVisualQCCBFvsGMWMTemplate - if == 1, uses the template GM and WM to make visualization overlays with CBF and other derived maps
+%                              if == 0, uses the individual GM and WM maps of the subject to make visualizations
+%                              (OPTIONAL, DEFAULT = 0)
+% x.bVisualQCCBFvsGMWMContour -  if == 1, then produces the WM and GM as a contour in the overlay with CBF and derived maps, not a full ROI - 1 pixel thickness (contour calculated per slice basis).
+%                              if == 0, then a standard full GM or WM ROI is used
+%                              (OPTIONAL, DEFAULT = 0)
+%   x.S.bMasking        - vector specifying if we should mask a ROI with a subject-specific mask
 %                       (1 = yes, 0 = no)
 %                       [1 0 0 0] = susceptibility mask (either population-or subject-wise)
 %                       [0 1 0 0] = vascular mask (only subject-wise)

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -185,8 +185,8 @@ x               = xASL_adm_ResetVisualizationSlices(x);
 % This can be either the individual map or the template WM map - based on the input parameters
 if isfield(x,'bVisualQCCBFvsGMWMTemplate') && ~isempty(x.bVisualQCCBFvsGMWMTemplate) && x.bVisualQCCBFvsGMWMTemplate == 1
 	% Use the template version for visualization and not the individual one
-	PathpWM = fullfile(x.D.MapsSPMmodifiedDir,'rc2T1.nii');
-	PathpGM = fullfile(x.D.MapsSPMmodifiedDir,'rc1T1.nii');
+	PathpWM = fullfile(x.D.MapsSPMmodifiedDir,'rc2T1_ASL_res.nii');
+	PathpGM = fullfile(x.D.MapsSPMmodifiedDir,'rc1T1_ASL_res.nii');
 	TextpWM = ['Temp_' x.SUBJECTS{x.iSubject}];
 	TextpGM = ['Temp_' x.SUBJECTS{x.iSubject}];
 else

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -46,6 +46,10 @@ fprintf('%s\n','print visual quality assurance checks');
 Parms.ModuleName = 'ASL';
 close all % close all Figures to avoid capturing & saving the wrong Figure
 
+if ~isfield(, 'vis')
+    x.vis = struct;
+end
+
 x = xASL_adm_LoadX(x, [], true); % assume x.mat is newer than x
 
 %% -----------------------------------------------------------------------------------
@@ -183,7 +187,7 @@ x = xASL_adm_ResetVisualizationSlices(x);
 
 % Path to the WM map used for the QC here
 % This can be either the individual map or the template WM map - based on the input parameters
-if isfield(x,'bVisualQCCBFvsGMWMTemplate') && ~isempty(x.bVisualQCCBFvsGMWMTemplate) && x.bVisualQCCBFvsGMWMTemplate == 1
+if isfield(x.vis,'bVisualQCCBFvsGMWMTemplate') && ~isempty(x.vis.bVisualQCCBFvsGMWMTemplate) && x.vis.bVisualQCCBFvsGMWMTemplate
 	% Use the template version for visualization and not the individual one
 	PathpWM = fullfile(x.D.MapsSPMmodifiedDir,'rc2T1_ASL_res.nii');
 	PathpGM = fullfile(x.D.MapsSPMmodifiedDir,'rc1T1_ASL_res.nii');
@@ -193,7 +197,7 @@ else
 	PathpWM = x.P.Pop_Path_PV_pWM;
 	PathpGM = x.P.Pop_Path_PV_pGM;
 
-	if isfield(x,'bVisualQCCBFvsGMWMContour') && ~isempty(x.bVisualQCCBFvsGMWMContour) && x.bVisualQCCBFvsGMWMContour == 1
+	if isfield(x.vis,'bVisualQCCBFvsGMWMContour') && ~isempty(x.vis.bVisualQCCBFvsGMWMContour) && x.vis.bVisualQCCBFvsGMWMContour
 		TextpWM = ['Reg_' x.SUBJECTS{x.iSubject}];
 		TextpGM = ['Reg_' x.SUBJECTS{x.iSubject}];
 	else
@@ -203,7 +207,7 @@ else
 end
 
 % If this option is defined, then do not use the full maps, but rather their contours
-if isfield(x,'bVisualQCCBFvsGMWMContour') && ~isempty(x.bVisualQCCBFvsGMWMContour) && x.bVisualQCCBFvsGMWMContour == 1
+if isfield(x.vis,'bVisualQCCBFvsGMWMContour') && ~isempty(x.vis.bVisualQCCBFvsGMWMContour) && x.vis.bVisualQCCBFvsGMWMContour
 	% Load the map
 	imGM = xASL_io_Nifti2Im(PathpGM);
 	imWM = xASL_io_Nifti2Im(PathpWM);

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -179,7 +179,7 @@ function x = xASL_qc_VisualCheckCollective_ASL(x)
 % M0 NoSmoothM0 NoSmoothM0 with overlay c1T1
 % TT TT with overlay c2T1
 
-x               = xASL_adm_ResetVisualizationSlices(x);
+x = xASL_adm_ResetVisualizationSlices(x);
 
 % Path to the WM map used for the QC here
 % This can be either the individual map or the template WM map - based on the input parameters
@@ -277,7 +277,7 @@ nIms = length(T.(Pars{1}));
 nRows = ceil( nIms/4);
 
 for iN=1:nRows
-    clear T2
+    T2 = struct;
     ImsI                    = (iN-1)*4+1:min(nIms,iN*4);
     nImsRow                 = length(ImsI);
     nRow1                   = 1:nImsRow;
@@ -307,17 +307,17 @@ for iN=1:nRows
         % Sagittal
         x.S.SagSlices   = []; % show no sagittal slices
         % Transversal
-        if      isempty(T2.TraSlices{iM})
+        if isempty(T2.TraSlices{iM})
                 x.S.TraSlices   = x.S.slicesLarge;
-        elseif  strcmp(T2.TraSlices{iM},'n/a')
+        elseif strcmp(T2.TraSlices{iM},'n/a')
                 x.S.TraSlices   = [];
         else
                 warning('Wrong slice choice');
         end
         % Coronal
-        if      isempty(T2.CorSlices{iM})
+        if isempty(T2.CorSlices{iM})
                 x.S.CorSlices   = x.S.slicesLarge+7;
-        elseif  strcmp(T2.CorSlices{iM},'n/a')
+        elseif strcmp(T2.CorSlices{iM},'n/a')
                 x.S.CorSlices   = [];
         else
                 warning('Wrong slice choice');
@@ -333,12 +333,8 @@ for iN=1:nRows
 end
 
 % Delete the temporary contours if they exist
-if exist(fullfile(x.SESSIONDIR,'pGMC.nii'),'file')
-	xASL_delete(fullfile(x.SESSIONDIR,'pGMC.nii'));
-end
-if exist(fullfile(x.SESSIONDIR,'pWMC.nii'),'file')
-	xASL_delete(fullfile(x.SESSIONDIR,'pWMC.nii'));
-end
+xASL_delete(fullfile(x.SESSIONDIR,'pGMC.nii'));
+xASL_delete(fullfile(x.SESSIONDIR,'pWMC.nii'));
 
 fprintf('\n');
    

--- a/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_VisualQC_ASL.m
@@ -192,8 +192,14 @@ if isfield(x,'bVisualQCCBFvsGMWMTemplate') && ~isempty(x.bVisualQCCBFvsGMWMTempl
 else
 	PathpWM = x.P.Pop_Path_PV_pWM;
 	PathpGM = x.P.Pop_Path_PV_pGM;
-	TextpWM = 'Reg';
-	TextpGM = 'Reg';
+
+	if isfield(x,'bVisualQCCBFvsGMWMContour') && ~isempty(x.bVisualQCCBFvsGMWMContour) && x.bVisualQCCBFvsGMWMContour == 1
+		TextpWM = ['Reg_' x.SUBJECTS{x.iSubject}];
+		TextpGM = ['Reg_' x.SUBJECTS{x.iSubject}];
+	else
+		TextpWM = 'Reg';
+		TextpGM = 'Reg';
+	end
 end
 
 % If this option is defined, then do not use the full maps, but rather their contours


### PR DESCRIPTION
Closes #182 
* Overlays in ASLCheck can now use also the template version of GM and WM and not only individual segmentations.
* Overlays in ASLCheck can now be also contours and not full ROIs.