### PR TITLE
#356 Single function for parsing SliceReadoutTime

### DIFF
--- a/Functions/xASL_quant_FEAST.m
+++ b/Functions/xASL_quant_FEAST.m
@@ -53,20 +53,19 @@ xASL_adm_CreateDir(x.D.TTCheckDir);
 for iSession=1:2
     % Load data
     CBF{iSession} = xASL_io_Nifti2Im(PathCBF{iSession});
-    Gradient{iSession} = xASL_io_Nifti2Im(fullfile(x.D.PopDir, ['SliceGradient_extrapolated_' x.P.SubjectID '_' x.SESSIONS{iSession} '.nii']));
+    SliceNumber = xASL_io_Nifti2Im(fullfile(x.D.PopDir, ['SliceGradient_extrapolated_' x.P.SubjectID '_' x.SESSIONS{iSession} '.nii']));
 	% Obtain the correct SliceTime
 	imASL = xASL_io_ReadNifti(x.P.Path_ASL4D);
 	nSlices = size(imASL.dat,3);
 	SliceTime = xASL_quant_SliceTimeVector(x,nSlices);
 	
     % Correct different PLD scales
-	imGradientRounded = round(Gradient{iSession});
-	imGradientRounded(imGradientRounded<1) = 1;
-	imGradientRounded(imGradientRounded>length(SliceTime)) = length(SliceTime);
-	PLD{iSession} = x.Q.Initial_PLD + SliceTime(imGradientRounded);
+	SliceNumber = round(SliceNumber);
+	SliceNumber(SliceNumber<1) = 1;
+	SliceNumber(SliceNumber>length(SliceTime)) = length(SliceTime);
+	PLD{iSession} = x.Q.Initial_PLD + SliceTime(SliceNumber);
 	
-    Gradient{iSession} = exp(PLD{iSession}./x.Q.BloodT1) / (2.*x.Q.LabelingEfficiency.*x.Q.BloodT1 .* (1- exp(-x.Q.LabelingDuration./x.Q.BloodT1)) );
-    CBF{iSession} = CBF{iSession}./Gradient{iSession};
+    CBF{iSession} = CBF{iSession}./(exp(PLD{iSession}./x.Q.BloodT1) / (2.*x.Q.LabelingEfficiency.*x.Q.BloodT1 .* (1- exp(-x.Q.LabelingDuration./x.Q.BloodT1)) ));
 end
 % Average different PLD scales
 PLD_combined= (PLD{1}+PLD{2})./2;

--- a/Functions/xASL_quant_SinglePLD.m
+++ b/Functions/xASL_quant_SinglePLD.m
@@ -1,11 +1,11 @@
-function [ScaleImage, CBF] = xASL_quant_SinglePLD(PWI, M0_im, SliceGradient, x)
+function [ScaleImage, CBF] = xASL_quant_SinglePLD(PWI, M0_im, imSliceNumber, x)
 %xASL_quant_SinglePLD % Perform a multi-step quantification
-% FORMAT: [ScaleImage[, CBF]] = xASL_quant_SinglePLD(PWI, M0_im, SliceGradient, x)
+% FORMAT: [ScaleImage[, CBF]] = xASL_quant_SinglePLD(PWI, M0_im, imSliceNumber, x)
 %
 % INPUT:
 %   PWI             - image matrix of perfusion-weighted image (REQUIRED)
 %   M0_im           - M0 image (can be a single number or image matrix) (REQUIRED)
-%   SliceGradient   - image matrix showing slice number in current ASL space (REQUIRED for 2D multi-slice)
+%   imSliceNumber   - image matrix showing slice number in current ASL space (REQUIRED for 2D multi-slice)
 %   x               - struct containing pipeline environment parameters (REQUIRED)
 %
 % OUTPUT:
@@ -32,7 +32,7 @@ function [ScaleImage, CBF] = xASL_quant_SinglePLD(PWI, M0_im, SliceGradient, x)
 %              PWI stage)
 %
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% EXAMPLE: [ScaleImage, CBF] = xASL_quant_SinglePLD(PWI, M0_im, SliceGradient, x);
+% EXAMPLE: [ScaleImage, CBF] = xASL_quant_SinglePLD(PWI, M0_im, imSliceNumber, x);
 % __________________________________
 % Copyright 2015-2019 ExploreASL
 
@@ -76,20 +76,20 @@ else
         case '2d' % Load slice gradient
             fprintf('%s\n','2D sequence, accounting for SliceReadoutTime');
 
-            SliceGradient = double(SliceGradient);
+            imSliceNumber = double(imSliceNumber);
             % Correct NaNs
             % Fix reslicing errors:
-            if sum(isnan(SliceGradient(:)))>0
-                SliceGradient = xASL_im_ndnanfilter(SliceGradient,'gauss',[16 16 16],2); % code doesn't smooth, only extrapolates
+            if sum(isnan(imSliceNumber(:)))>0
+                imSliceNumber = xASL_im_ndnanfilter(imSliceNumber,'gauss',[16 16 16],2); % code doesn't smooth, only extrapolates
             end
 
-            SliceGradient(~isfinite(SliceGradient)) = 1;
-            SliceGradient(SliceGradient<1) = 1;
+            imSliceNumber(~isfinite(imSliceNumber)) = 1;
+            imSliceNumber(imSliceNumber<1) = 1;
 			
-			imGradientRounded = round(SliceGradient);
-			imGradientRounded(imGradientRounded<1) = 1;
-			imGradientRounded(imGradientRounded>length(SliceTime)) = length(SliceTime);
-			ScaleImage = ScaleImage.*(x.Q.Initial_PLD + SliceTime(imGradientRounded)); % effective/net PLD
+			imSliceNumber = round(imSliceNumber);
+			imSliceNumber(imSliceNumber<1) = 1;
+			imSliceNumber(imSliceNumber>length(SliceTime)) = length(SliceTime);
+			ScaleImage = ScaleImage.*(x.Q.Initial_PLD + SliceTime(imSliceNumber)); % effective/net PLD
         otherwise
             error('Wrong x.readout_dim value!');
     end

--- a/Functions/xASL_quant_SliceReadoutTime_ShortestTR.m
+++ b/Functions/xASL_quant_SliceReadoutTime_ShortestTR.m
@@ -38,7 +38,8 @@ function [x] = xASL_quant_SliceReadoutTime_ShortestTR(x)
 
         if isfield(ASL_parms,'RepetitionTime')
             %  Load original file to get nSlices
-            nSlices = size(xASL_io_Nifti2Im(x.P.Path_ASL4D),3);
+			imASL = xASL_io_ReadNifti(x.P.Path_ASL4D);
+			nSlices = size(imASL.dat,3);
             x.Q.SliceReadoutTime = (ASL_parms.RepetitionTime-x.Q.LabelingDuration-x.Q.Initial_PLD)/nSlices;
         else
             warning('ASL_parms.RepetitionTime expected but did not exist!');
@@ -47,8 +48,8 @@ function [x] = xASL_quant_SliceReadoutTime_ShortestTR(x)
 
     %% ---------------------------------------------------
     %% Check output
-    if isnan(x.Q.SliceReadoutTime)
-        error('qnt_PLDslicereadout expected but was NaN');
+    if max(isnan(x.Q.SliceReadoutTime))
+        error('SliceTime expected but was NaN');
 	else
 		if length(x.Q.SliceReadoutTime) == 1
 			ScalarSliceReadoutTime = x.Q.SliceReadoutTime(1);

--- a/Functions/xASL_quant_SliceTimeVector.m
+++ b/Functions/xASL_quant_SliceTimeVector.m
@@ -1,0 +1,75 @@
+function SliceTime = xASL_quant_SliceTimeVector(x,nSlices)
+%xASL_quant_SliceTimeVector Calculates the vector of slice-times for the given number of slices
+%
+% FORMAT: SliceTime = xASL_quant_SliceTimeVector(x,nSlices)
+%
+% INPUT:
+%   x          - struct containing pipeline environment parameters (REQUIRED)
+%   nSlices    - number of slices in ASL native space to calculate the SliceTime for (REQUIRED)
+% OUTPUT:
+%   SliceTime  - a vector of SliceTimes with the length nSlices
+% -----------------------------------------------------------------------------------------------------------------------------------------------------
+% DESCRIPTION: This function takes the x.SliceReadoutTime, which can be a vector or scalar and creates a vector
+%              out of it with the correct length. It also checks the x.readout_dim for which it returns 0.
+%
+% 0. Admin
+% 1. ShortestTR
+% 2. Assign the vector value
+% -----------------------------------------------------------------------------------------------------------------------------------------------------
+% EXAMPLE: SliceTime = xASL_quant_SliceTimeVector(x,32)
+% __________________________________
+% Copyright 2015-2021 ExploreASL
+
+%% -----------------------------------------------------------------------------------------------------------------------------------------------------
+%% 0.Admin
+if nargin < 1 || isempty(x)
+	error('The x-structure needs to be provided');
+end
+
+if nargin < 2 || isempty(nSlices) 
+	error('The nSlices parameter needs to be provided');
+end
+
+% The readout_dim needs to be provided
+if ~isfield(x,'readout_dim')
+	error('x.readout_dim field is missing');
+end
+
+if strcmpi(x.readout_dim, '3D')
+	% For 3D sequences, zero is returned
+	SliceTime = 0;
+	return;
+end
+
+if ~strcmpi(x.readout_dim, '2D') 
+	% It only works with 2D and 3D
+	error(['Unknown x.readout_dim value:' x.readout_dim]);
+end
+
+% The SliceReadoutTime needs to be provided
+if ~isfield(x, 'Q')
+	error('x.Q field missing');
+elseif ~isfield(x.Q, 'SliceReadoutTime') || isempty(x.Q.SliceReadoutTime)
+	error('x.Q.SliceReadoutTime missing or invalid ');
+end
+
+%% -----------------------------------------------------------------------------------------------------------------------------------------------------
+%% 1. ShortestTR
+% If SliceReadoutTiem is specified as "shortestTR", it calculates it with the knowledge of TR and PLD
+% If a scalar or vector is given for SliceReadoutTime, then this function doesn't do anything
+x = xASL_quant_SliceReadoutTime_ShortestTR(x);
+
+%% -----------------------------------------------------------------------------------------------------------------------------------------------------
+%% 2. Assign the vector value
+% For 2D it either uses the vector or it replicates the scalar to the correct length
+% Non-2D cases were solved in the admin
+
+if length(x.Q.SliceReadoutTime) == 1
+	SliceTime = (0:1:(nSlices-1)) * x.Q.SliceReadoutTime;
+elseif length(x.Q.SliceReadoutTime) == nSlices
+	SliceTime = x.Q.SliceReadoutTime;
+else
+	error('x.Q.SliceReadoutTime has to be a scalar or match the number of slices');
+end
+
+end


### PR DESCRIPTION
Closes #356 

Created a single central function from parsing the SliceReadoutTime parameter. It checks for 2D and 3D readout and if the SliceReadoutTime is a vector or scalar and then produces a vector with the length corresponding to the number of slices in the native ASL. 

This issue does not change the functionality, but rather cleans the code and puts all the checks to a single function, while previously they were everywhere.

### Release changes
Move current SliceReadoutTime parsing from throughout the pipeline to a single function