### PR TITLE
#403 changes x.M0_usesASLtiming explanation fix

### DIFF
--- a/Functions/xASL_quant_M0.m
+++ b/Functions/xASL_quant_M0.m
@@ -148,7 +148,7 @@ else
 
 		if  x.M0_usesASLtiming
 			% in this case, the M0 readout has the exact same timing as the ASL readout
-			% this is the case e.g. for Philips 3D GRASE
+			% this is the case e.g. for Siemens 2D EPI
 			NetTR = x.Q.LabelingDuration+x.Q.Initial_PLD+SliceReadoutTime(SliceIM);
 
 			fprintf('%s\n','2D sliceWise M0 readout assumed, same timing as ASL slices readout used');


### PR DESCRIPTION
xASL_quant_M0: x.M0_usesASLtiming explains the following:

'% in this case, the M0 readout has the exact same timing as the ASL readout
% this is the case e.g. for Philips 3D GRASE'

The explanation only has to be adjusted to a 2D sequence as this step in the code is only for 2D sequences. 

### Release note
Very minor edit in comments, can be aggregated with other commits under a text: Improved inline comments in the code.