### PR TITLE
#184 subject-specific masking vector changed

### DIFF
--- a/Functions/xASL_stat_ComputeMean.m
+++ b/Functions/xASL_stat_ComputeMean.m
@@ -84,7 +84,7 @@ end
 imMask = imMask>0 & isfinite(imCBF);
 % Constrain calculation to the mask and to finite values
 imCBF = imCBF(imMask);
-imCBF(imCBF == 0 ) = NaN; %%%% testing for #184
+imCBF(imCBF == 0 ) = NaN; % convert to NaN's for correct masking
 
 % Limits imGM and imWM to imMask, if provided
 if ~isempty(imGM)

--- a/Functions/xASL_stat_ComputeMean.m
+++ b/Functions/xASL_stat_ComputeMean.m
@@ -82,9 +82,9 @@ end
 
 % only compute in real data
 imMask = imMask>0 & isfinite(imCBF);
-
 % Constrain calculation to the mask and to finite values
 imCBF = imCBF(imMask);
+imCBF(imCBF == 0 ) = NaN; %%%% testing for #184
 
 % Limits imGM and imWM to imMask, if provided
 if ~isempty(imGM)

--- a/Functions/xASL_stat_GetROIstatistics.m
+++ b/Functions/xASL_stat_GetROIstatistics.m
@@ -116,6 +116,8 @@ elseif isequal(x.S.bMasking, 0)
     x.S.bMasking = [0 0 0 0];
 end
 
+    x.S.bMasking = [1 1 1 1]; % test for low CBF values #184
+
 if ~x.S.IsASL
     x.S.bMasking(3) = 0; % disable tissue masking
 end

--- a/Functions/xASL_stat_GetROIstatistics.m
+++ b/Functions/xASL_stat_GetROIstatistics.m
@@ -116,8 +116,6 @@ elseif isequal(x.S.bMasking, 0)
     x.S.bMasking = [0 0 0 0];
 end
 
-    x.S.bMasking = [1 1 1 1]; % test for low CBF values #184
-
 if ~x.S.IsASL
     x.S.bMasking(3) = 0; % disable tissue masking
 end


### PR DESCRIPTION
In test subject Philips_2DEPI_Lesion_NoFLAIR_NoM0_HiQ has too low values

- Check the partial volume correction

- Check about the small FOV