### PR TITLE
#454 xASL_qc_TestExploreASL backwards compatibility fix

### DIFF
--- a/Development/xASL_qc_TestExploreASL.m
+++ b/Development/xASL_qc_TestExploreASL.m
@@ -457,7 +457,7 @@ save(SaveFile, 'ResultsTable');
 try
     % Find all result tables in directory
     AllResultTables = xASL_adm_GetFsList(fullfile(TestDirOrig),'^.+\_ResultsTable.mat$',false)';
-    IndexCurrentTable = find(contains(AllResultTables, ResultTableFile));
+    IndexCurrentTable = find(~isempty(strfind(AllResultTables, ResultTableFile)));
     if ~isempty(IndexCurrentTable)
         AllResultTables(IndexCurrentTable) = [];
     end


### PR DESCRIPTION
In xASL_qc_TestExploreASL.m, replaced:
`contains`

with

`~isempty(strfind())`