### PR TITLE
#583 xASL_test_IntegrationTesting: Initial implementation

### DIFF
--- a/Development/BIDS/BIDS_fullPipelineTest.m
+++ b/Development/BIDS/BIDS_fullPipelineTest.m
@@ -61,25 +61,25 @@ end
 %% Test execution
 
 % Prepare the data
-xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [1 0 0 0 0 0 0], x);
+xASL_test_Flavors(pathExploreASL, pathTest, [1 0 0 0 0 0 0], x);
 
 % Convert to BIDS
-xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [0 1 0 0 0 0 0], x);
+xASL_test_Flavors(pathExploreASL, pathTest, [0 1 0 0 0 0 0], x);
 
 % Check the BIDS conversion
-xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [0 0 1 0 0 0 0], x);
+xASL_test_Flavors(pathExploreASL, pathTest, [0 0 1 0 0 0 0], x);
 
 % Convert BIDS to Legacy
-xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [0 0 0 1 0 0 0], x);
+xASL_test_Flavors(pathExploreASL, pathTest, [0 0 0 1 0 0 0], x);
 
 % Check the Legacy conversion
-%xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [0 0 0 0 1 0 0], x);
+%xASL_test_Flavors(pathExploreASL, pathTest, [0 0 0 0 1 0 0], x);
 
 % Run the pipeline
-xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [0 0 0 0 0 1 0], x);
+xASL_test_Flavors(pathExploreASL, pathTest, [0 0 0 0 0 1 0], x);
 
 % Check the pipeline results
-%xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, [0 0 0 0 0 0 1], x);
+%xASL_test_Flavors(pathExploreASL, pathTest, [0 0 0 0 0 0 1], x);
 
 % Get warnings & errors from log files
 [logContent] = xASL_test_GetLogContent(pathTest,0,1,2);

--- a/Functions/xASL_adm_RemoveDirectories.m
+++ b/Functions/xASL_adm_RemoveDirectories.m
@@ -21,13 +21,10 @@ function xASL_adm_RemoveDirectories(root)
     end
     
     % ExploreASL
-    try
-        warning('off', 'MATLAB:rmpath:DirNotFound');
-        rmpath(genpath(root));
-        warning('on', 'MATLAB:rmpath:DirNotFound');
-    catch ME
-        fprintf('%s\n', ME.message);
-    end
+    warning('off', 'MATLAB:rmpath:DirNotFound');
+    rmpath(genpath(root));
+    warning('on', 'MATLAB:rmpath:DirNotFound');
+
 
 end
 

--- a/Functions/xASL_adm_RemoveDirectories.m
+++ b/Functions/xASL_adm_RemoveDirectories.m
@@ -22,9 +22,9 @@ function xASL_adm_RemoveDirectories(root)
     
     % ExploreASL
     try
-        warning('off', 'all');
+        warning('off', 'MATLAB:rmpath:DirNotFound');
         rmpath(genpath(root));
-        warning('on', 'all');
+        warning('on', 'MATLAB:rmpath:DirNotFound');
     catch ME
         fprintf('%s\n', ME.message);
     end

--- a/Functions/xASL_adm_RemoveDirectories.m
+++ b/Functions/xASL_adm_RemoveDirectories.m
@@ -1,0 +1,36 @@
+function xASL_adm_RemoveDirectories(root)
+%xASL_adm_RemoveDirectories Script to remove all ExploreASL related paths
+%
+% FORMAT:       xASL_adm_RemoveDirectories(root)
+% 
+% INPUT:        root - Root directory (REQUIRED, CHAR ARRAY)
+%
+% OUTPUT:       n/a
+% 
+% -----------------------------------------------------------------------------------------------------------------------------------------------------
+% DESCRIPTION:  Script to remove all ExploreASL related paths.
+%
+% -----------------------------------------------------------------------------------------------------------------------------------------------------
+% EXAMPLE:      xASL_adm_RemoveDirectories(x.MyPath);
+% __________________________________
+% Copyright 2015-2021 ExploreASL
+
+    %% Check input
+    if nargin < 1
+        error('Please provide a root directory...');
+    end
+    
+    % ExploreASL
+    try
+        warning('off', 'all');
+        rmpath(genpath(root));
+        warning('on', 'all');
+    catch ME
+        fprintf('%s\n', ME.message);
+    end
+
+end
+
+
+
+

--- a/Functions/xASL_test_BIDSConversion.m
+++ b/Functions/xASL_test_BIDSConversion.m
@@ -1,12 +1,10 @@
-function xASL_test_BIDSConversion(baseDirImport, baseDirReference, bImport)
-%xASL_test_BIDSConversion Convert ASL flavors from DICOM to BIDS, comparing the results with reference data
+function xASL_test_BIDSConversion(baseDirImport)
+%xASL_test_BIDSConversion Convert ASL flavors from DICOM to BIDS
 %
-% FORMAT: xASL_test_BIDSConversion(baseDirImport[, baseDirReference, bImport])
+% FORMAT: xASL_test_BIDSConversion(baseDirImport)
 %
 % INPUT:
 %   baseDirImport    - Directory for import - sourcedata files are in the 'sourcedata' folder (REQUIRED)
-%   baseDirReference - Reference directory with correct ASL-BIDS data (OPTIONAL)
-%   bImport          - Specify if import should be performed (OPTIONAL, DEFAULT=TRUE)
 %
 % OUTPUT: n/a        - Outputs the converted data and comparison results are printed on screen
 %         
@@ -28,19 +26,8 @@ function xASL_test_BIDSConversion(baseDirImport, baseDirReference, bImport)
 % 4. Convert NII+JSON -> BIDS
 %
 % EXAMPLE: xASL_test_BIDSConversion('mydir/testImport');
-%          xASL_test_BIDSConversion('mydir/testImport', 'mydir/testReference',0,1);
 % __________________________________
-% Copyright 2015-2020 ExploreASL
-
-
-%% Admin
-if nargin<2 || isempty(baseDirReference)
-	baseDirReference = ''; % isempty() is from [], so still needs conversion
-end
-
-if nargin<3 || isempty(bImport)
-	bImport = true;
-end
+% Copyright 2015-2021 ExploreASL
 
 %% 1. Initialization
 % Initialize ExploreASL 
@@ -49,82 +36,74 @@ x = ExploreASL_Initialize;
 % Load the list of the directories
 flavorList = xASL_adm_GetFileList(baseDirImport, [], false, [], true);
 
-if bImport
-	for iFlavor = 1:length(flavorList)
-        
-        %% 2. DICOM -> NII+JSON (i.e. dcm2niiX)
-        xASL_module_Import(fullfile(baseDirImport, flavorList{iFlavor}), [],[], [1 0 0], false, true, false, false, x);
-        DirASL = fullfile(baseDirImport, flavorList{iFlavor}, 'temp', 'Sub1', 'ASL_1');
-        
-        %% 3. Manual curation for certain flavors
-		switch (flavorList{iFlavor})
+
+for iFlavor = 1:length(flavorList)
+	
+	%% 2. DICOM -> NII+JSON (i.e. dcm2niiX)
+	ExploreASL(fullfile(baseDirImport, flavorList{iFlavor}), [1 0 0 0], 0, 0);
+	DirASL = fullfile(baseDirImport, flavorList{iFlavor}, 'temp', 'Sub1', 'ASL_1');
+	
+	%% 3. Manual curation for certain flavors
+	switch (flavorList{iFlavor})
 		
-            % 3a. 'Siemens_PCASL_3DGRASE_vascular'
-			case 'Siemens_PCASL_3DGRASE_vascular'
-                
-                xASL_adm_DeleteFileList(DirASL, '^ASL4D_(32|33|34|35)_00001.*$', 1);
-
-				nii_files = xASL_adm_GetFileList(DirASL, '^.*\.nii$', 'FPList', [], false);
-				xASL_bids_MergeNifti(nii_files, 'ASL');
-				
-            % 3b. 'Philips_PCASL_3DGRASE_R5.4_TopUp'
-			case 'Philips_PCASL_3DGRASE_R5.4_TopUp'
-                DirASL = fullfile(baseDirImport, flavorList{iFlavor}, 'temp', 'Sub1', 'ASL_1');
-                
-				xASL_Move(fullfile(DirASL, 'M0_601_00001.nii'), fullfile(DirASL, 'M0.nii'), 1);
-				xASL_Move(fullfile(DirASL, 'M0_601_00001.json'), fullfile(DirASL, 'M0.json'), 1);
-				xASL_Move(fullfile(DirASL, 'M0_701_00001.nii'), fullfile(DirASL, 'M0PERev.nii'), 1);
-				xASL_Move(fullfile(DirASL, 'M0_701_00001.json'), fullfile(DirASL, 'M0PERev.json'), 1);
-				
-            % 3c. 'Siemens_PCASL_volunteer'
-			case 'Siemens_PCASL_volunteer'
-                
-				if xASL_exist(fullfile(DirASL, 'ASL4D_NS.nii'))
-					xASL_delete(fullfile(DirASL, 'ASL4D_NS.json'));
-					xASL_Move(fullfile(DirASL, 'ASL4D_SS.json'), fullfile(DirASL, 'ASL4D.json'), 1);
-                              
-					imNS = xASL_io_Nifti2Im(fullfile(DirASL, 'ASL4D_NS.nii'));
-					imSS = xASL_io_Nifti2Im(fullfile(DirASL, 'ASL4D_SS.nii'));
-					imNS(:,:,:,2) = imSS;
-					xASL_io_SaveNifti(fullfile(DirASL, 'ASL4D_NS.nii'), fullfile(DirASL, 'ASL4D.nii'), imNS/10, [], 1);
-                        
-					xASL_delete(fullfile(DirASL, 'ASL4D_NS.nii'));
-					xASL_delete(fullfile(DirASL, 'ASL4D_SS.nii'));
-                    
-					xASL_Move(fullfile(DirASL, 'M0_2.json'), fullfile(DirASL, 'M0PERev.json'), 1);
-					xASL_Move(fullfile(DirASL, 'M0_2.nii'), fullfile(DirASL, 'M0PERev.nii'), 1);
-				end
-				
-            % 3d. 'Siemens_PCASL_multiTI'
-			case 'Siemens_PCASL_multiTI'
-                
-				if xASL_exist(fullfile(DirASL, 'ASL4D_NS_300.nii'))
-					mTIvector = [300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000];
-					for iTI = 1:length(mTIvector)
-						if iTI>1
-                            xASL_delete(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.json']));
-                            xASL_delete(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.json']));
-							imNSSS(:,:,:,2*(iTI-1)+1) = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.nii']));
-							imNSSS(:,:,:,2*(iTI-1)+2) = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.nii']));
-                        else
-                            xASL_Move(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.json']), fullfile(DirASL, 'ASL4D.json'));
-                            xASL_delete(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.json']));
-							imNSSS = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.nii']));
-							imNSSS(:,:,:,2) = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.nii']));
-						end
-					end
-					xASL_io_SaveNifti(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(1)) '.nii']),...
-                        fullfile(DirASL, 'ASL4D.nii'), imNSSS/10, [], 1, []);
-					for iTI = 1:length(mTIvector)
-						xASL_delete(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.nii']));
-						xASL_delete(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.nii']));
+		% 3a. 'Siemens_PCASL_3DGRASE_vascular'
+		case 'Siemens_PCASL_3DGRASE_vascular'
+			
+			xASL_adm_DeleteFileList(DirASL, '^ASL4D_(32|33|34|35)_00001.*$', 1);
+			
+			nii_files = xASL_adm_GetFileList(DirASL, '^.*\.nii$', 'FPList', [], false);
+			xASL_bids_MergeNifti(nii_files, 'ASL');
+			
+			% 3b. 'Philips_PCASL_3DGRASE_R5.4_TopUp'
+		case 'Philips_PCASL_3DGRASE_R5.4_TopUp'
+			DirASL = fullfile(baseDirImport, flavorList{iFlavor}, 'temp', 'Sub1', 'ASL_1');
+			
+			xASL_Move(fullfile(DirASL, 'M0_601_00001.nii'), fullfile(DirASL, 'M0.nii'), 1);
+			xASL_Move(fullfile(DirASL, 'M0_601_00001.json'), fullfile(DirASL, 'M0.json'), 1);
+			xASL_Move(fullfile(DirASL, 'M0_701_00001.nii'), fullfile(DirASL, 'M0PERev.nii'), 1);
+			xASL_Move(fullfile(DirASL, 'M0_701_00001.json'), fullfile(DirASL, 'M0PERev.json'), 1);
+			
+			% 3c. 'Siemens_PCASL_volunteer'
+		case 'Siemens_PCASL_volunteer'
+			imNS = xASL_io_Nifti2Im(fullfile(DirASL, 'ASL4D_NS.nii'));
+			imSS = xASL_io_Nifti2Im(fullfile(DirASL, 'ASL4D_SS.nii'));
+			imNS(:,:,:,2) = imSS;
+			xASL_io_SaveNifti(fullfile(DirASL, 'ASL4D_NS.nii'), fullfile(DirASL, 'ASL4D.nii'), imNS/10, [], 1);
+			
+			xASL_delete(fullfile(DirASL, 'ASL4D_NS.nii'));
+			xASL_delete(fullfile(DirASL, 'ASL4D_SS.nii'));
+			
+			xASL_Move(fullfile(DirASL, 'M0_2.json'), fullfile(DirASL, 'M0PERev.json'), 1);
+			xASL_Move(fullfile(DirASL, 'M0_2.nii'), fullfile(DirASL, 'M0PERev.nii'), 1);
+			
+			% 3d. 'Siemens_PCASL_multiTI'
+		case 'Siemens_PCASL_multiTI'
+			
+			if xASL_exist(fullfile(DirASL, 'ASL4D_NS_300.nii'))
+				mTIvector = [300, 600, 900, 1200, 1500, 1800, 2100, 2400, 2700, 3000];
+				for iTI = 1:length(mTIvector)
+					if iTI>1
+						xASL_delete(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.json']));
+						xASL_delete(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.json']));
+						imNSSS(:,:,:,2*(iTI-1)+1) = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.nii']));
+						imNSSS(:,:,:,2*(iTI-1)+2) = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.nii']));
+					else
+						xASL_Move(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.json']), fullfile(DirASL, 'ASL4D.json'));
+						xASL_delete(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.json']));
+						imNSSS = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.nii']));
+						imNSSS(:,:,:,2) = xASL_io_Nifti2Im(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.nii']));
 					end
 				end
-		end
-        
-        %% 4. Convert NII+JSON -> BIDS
-        xASL_module_Import(fullfile(baseDirImport, flavorList{iFlavor}), [],[], [0 1 0], false, true, false, false, x);
-	end % for iFlavor
-end % if bImport
+				xASL_io_SaveNifti(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(1)) '.nii']),...
+					fullfile(DirASL, 'ASL4D.nii'), imNSSS/10, [], 1, []);
+				for iTI = 1:length(mTIvector)
+					xASL_delete(fullfile(DirASL, ['ASL4D_NS_' xASL_num2str(mTIvector(iTI)) '.nii']));
+					xASL_delete(fullfile(DirASL, ['ASL4D_SS_' xASL_num2str(mTIvector(iTI)) '.nii']));
+				end
+			end
+	end
+	
+	%% 4. Convert NII+JSON -> BIDS
+	ExploreASL(fullfile(baseDirImport, flavorList{iFlavor}), [0 1 0 0], 0, 0);
+end % for iFlavor
 
-end

--- a/Functions/xASL_test_BIDSConversion.m
+++ b/Functions/xASL_test_BIDSConversion.m
@@ -1,13 +1,12 @@
-function xASL_test_BIDSConversion(baseDirImport, baseDirReference, bImport, bComparison)
+function xASL_test_BIDSConversion(baseDirImport, baseDirReference, bImport)
 %xASL_test_BIDSConversion Convert ASL flavors from DICOM to BIDS, comparing the results with reference data
 %
-% FORMAT: xASL_test_BIDSConversion(baseDirImport[, baseDirReference, bImport, bComparison])
+% FORMAT: xASL_test_BIDSConversion(baseDirImport[, baseDirReference, bImport])
 %
 % INPUT:
 %   baseDirImport    - Directory for import - sourcedata files are in the 'sourcedata' folder (REQUIRED)
 %   baseDirReference - Reference directory with correct ASL-BIDS data (OPTIONAL)
 %   bImport          - Specify if import should be performed (OPTIONAL, DEFAULT=TRUE)
-%   bComparison      - Specify if comparison should be performed (OPTIONAL, DEFAULT=FALSE)
 %
 % OUTPUT: n/a        - Outputs the converted data and comparison results are printed on screen
 %         
@@ -27,7 +26,6 @@ function xASL_test_BIDSConversion(baseDirImport, baseDirReference, bImport, bCom
 % 3c. Siemens_PCASL_volunteer
 % 3d. Siemens_PCASL_multiTI
 % 4. Convert NII+JSON -> BIDS
-% 5. Run the comparison with the reference directory
 %
 % EXAMPLE: xASL_test_BIDSConversion('mydir/testImport');
 %          xASL_test_BIDSConversion('mydir/testImport', 'mydir/testReference',0,1);
@@ -42,14 +40,6 @@ end
 
 if nargin<3 || isempty(bImport)
 	bImport = true;
-end
-
-if nargin<4 || isempty(bComparison)
-	bComparison = false;
-end
-
-if bComparison && isempty(baseDirReference)
-	error('Cannot compare to a reference if the reference directory missing');
 end
 
 %% 1. Initialization
@@ -136,19 +126,5 @@ if bImport
         xASL_module_Import(fullfile(baseDirImport, flavorList{iFlavor}), [],[], [0 1 0], false, true, false, false, x);
 	end % for iFlavor
 end % if bImport
-
-
-%% 5. Run the comparison with the reference directory
-if bComparison
-	% List all studies in the import directory
-	filenameCompare = xASL_adm_GetFileList(baseDirImport, '^.+$', 'List', [], true);
-	for iCompare = 1:length(filenameCompare)
-		% Compare the imported data in the 'rawdata' subdirectory with the counterpart
-		fprintf('%s\n', ['Dataset: '  filenameCompare{iCompare}]);
-		xASL_bids_CompareStructures(fullfile(baseDirImport, filenameCompare{iCompare}, 'rawdata'),...
-            fullfile(baseDirReference, filenameCompare{iCompare}, 'rawdata'),[],[],0,1);
-	end
-end
-
 
 end

--- a/Functions/xASL_test_BIDSFlavorsFull.m
+++ b/Functions/xASL_test_BIDSFlavorsFull.m
@@ -120,7 +120,14 @@ end
 
 %% 3. Run the comparison of converted BIDS with the reference data
 if bTest(3)
-	xASL_test_BIDSConversion(conversionPath, referencePath, 0, 1);
+	% List all studies in the import directory
+	filenameCompare = xASL_adm_GetFileList(conversionPath, '^.+$', 'List', [], true);
+	for iCompare = 1:length(filenameCompare)
+		% Compare the imported data in the 'rawdata' subdirectory with the counterpart
+		fprintf('%s\n', ['Dataset: '  filenameCompare{iCompare}]);
+		xASL_bids_CompareStructures(fullfile(conversionPath, filenameCompare{iCompare}, 'rawdata'),...
+            fullfile(referencePath, filenameCompare{iCompare}, 'rawdata'),[],[],0,1);
+	end
 end
 
 %% 4. Run the BIDS to Legacy conversion

--- a/Functions/xASL_test_BIDSFlavorsFull.m
+++ b/Functions/xASL_test_BIDSFlavorsFull.m
@@ -1,6 +1,5 @@
 function xASL_test_BIDSFlavorsFull(pathExploreASL,pathTest,bTest,x)
-%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% Runs the complete testing of BIDS flavors including import, processing and comparison
+%xASL_test_BIDSFlavorsFull Runs the complete testing of BIDS flavors including import, processing and comparison
 %
 % FORMAT: xASL_test_BIDSFlavorsFull(pathExploreASL,pathTest)
 %
@@ -151,11 +150,13 @@ if bTest(4)
 			fListDataPar = xASL_adm_GetFileList(ListFolders{iList},'(?i)(^dataPar.*\.json$)', 'FPList', [], 0);
 			if length(fListDataPar) < 1
 				% Fill the dataPars with default parameters
-				xASL_bids_BIDS2Legacy(ListFolders{iList}, 1, defaultDataPar);
+				pathDefaultDataPar = fullfile(ListFolders{iList},'dataPar.json');
+				spm_jsonwrite(pathDefaultDataPar,defaultDataPar);
+				ExploreASL(ListFolders{iList}, [0 0 0 1], 0, 0);
+				xASL_delete(pathDefaultDataPar);
 			else
 				% Fill the dataPars with the provided parameters
-				dataPar = spm_jsonread(fListDataPar{1});
-				xASL_bids_BIDS2Legacy(ListFolders{iList}, 1, dataPar);
+				ExploreASL(ListFolders{iList}, [0 0 0 1], 0, 0);
 			end
 			
 		end
@@ -176,7 +177,7 @@ if bTest(6)
 		if exist(pathDerivatives,'dir')
 			pathDerivatives = fullfile(pathDerivatives,'ExploreASL');
 			if exist(pathDerivatives,'dir')
-				ExploreASL_Master(fullfile(pathDerivatives,'dataPar.json'), 0, [1 1 0], 0); % Don't run population module
+				ExploreASL(fullfile(pathDerivatives,'dataPar.json'), 0, [1 1 0], 0); % Don't run population module
 			end
 		end
 	end

--- a/Functions/xASL_test_BIDSFlavorsFull.m
+++ b/Functions/xASL_test_BIDSFlavorsFull.m
@@ -1,7 +1,7 @@
-function xASL_test_BIDSFlavorsFull(pathExploreASL,pathTest,bTest,x)
+function xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, bTest, x)
 %xASL_test_BIDSFlavorsFull Runs the complete testing of BIDS flavors including import, processing and comparison
 %
-% FORMAT: xASL_test_BIDSFlavorsFull(pathExploreASL,pathTest)
+% FORMAT: xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest[, bTest, x])
 %
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % 
@@ -20,6 +20,7 @@ function xASL_test_BIDSFlavorsFull(pathExploreASL,pathTest,bTest,x)
 %   x              - x structure (OPTIONAL, DEFAULT = run Initialization)
 %
 % OUTPUT: 
+%  n/a
 % 
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % DESCRIPTION: Runs the full testing on import and processing of the FlavorsDatabase. The testing directory
@@ -28,7 +29,7 @@ function xASL_test_BIDSFlavorsFull(pathExploreASL,pathTest,bTest,x)
 %              directory.
 %
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% EXAMPLE:     xASL_test_BIDSFlavorsFull('/home/user/ExploreASL','/home/user/tmp',[0 1 1 0 1])
+% EXAMPLE:     xASL_test_BIDSFlavorsFull('/home/user/ExploreASL', '/home/user/tmp', [0 1 1 0 1], x)
 % __________________________________
 % Copyright 2015-2021 ExploreASL
 
@@ -115,7 +116,7 @@ end
 
 %% 2. Run the conversion of source data to BIDS
 if bTest(2)
-	xASL_test_BIDSConversion(conversionPath, referencePath, 1, 0);
+	xASL_test_BIDSConversion(conversionPath);
 end
 
 %% 3. Run the comparison of converted BIDS with the reference data

--- a/Functions/xASL_test_Flavors.m
+++ b/Functions/xASL_test_Flavors.m
@@ -1,7 +1,7 @@
-function xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, bTest, x)
-%xASL_test_BIDSFlavorsFull Runs the complete testing of BIDS flavors including import, processing and comparison
+function xASL_test_Flavors(pathExploreASL, pathTest, bTest, x)
+%xASL_test_Flavors Runs the complete testing of Flavors including import from DICOM to BIDS, processing and comparison
 %
-% FORMAT: xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest[, bTest, x])
+% FORMAT: xASL_test_Flavors(pathExploreASL, pathTest[, bTest, x])
 %
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % 
@@ -29,7 +29,7 @@ function xASL_test_BIDSFlavorsFull(pathExploreASL, pathTest, bTest, x)
 %              directory.
 %
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% EXAMPLE:     xASL_test_BIDSFlavorsFull('/home/user/ExploreASL', '/home/user/tmp', [0 1 1 0 1], x)
+% EXAMPLE:     xASL_test_Flavors('/home/user/ExploreASL', '/home/user/tmp', [0 1 1 0 1], x)
 % __________________________________
 % Copyright 2015-2021 ExploreASL
 
@@ -116,7 +116,7 @@ end
 
 %% 2. Run the conversion of source data to BIDS
 if bTest(2)
-	xASL_test_BIDSConversion(conversionPath);
+	xASL_test_Flavors_DCM2BIDS(conversionPath, x);
 end
 
 %% 3. Run the comparison of converted BIDS with the reference data
@@ -185,7 +185,7 @@ if bTest(6)
 		if exist(pathDerivatives,'dir')
 			pathDerivatives = fullfile(pathDerivatives,'ExploreASL');
 			if exist(pathDerivatives,'dir')
-				ExploreASL(fullfile(pathDerivatives,'dataPar.json'), 0, [1 1 0], 0); % Don't run population module
+				ExploreASL(pathDerivatives, 0, [1 1 0], 0); % Don't run population module
 			end
 		end
 	end

--- a/Functions/xASL_test_Flavors.m
+++ b/Functions/xASL_test_Flavors.m
@@ -50,8 +50,15 @@ end
 cd(pathExploreASL);
 
 if nargin < 4 || isempty(x)
+    % Remove existing paths
+    thisDirectory = pwd;
+    if ~isempty(pathExploreASL)
+        xASL_adm_RemoveDirectories(pathExploreASL);
+        cd(pathExploreASL);
+    end
     % Initialize ExploreASL
     ExploreASL_Initialize;
+    cd(thisDirectory);
 end
 
 % Initialize the working paths

--- a/Functions/xASL_test_Flavors_DCM2BIDS.m
+++ b/Functions/xASL_test_Flavors_DCM2BIDS.m
@@ -1,7 +1,7 @@
-function xASL_test_BIDSConversion(baseDirImport)
-%xASL_test_BIDSConversion Convert ASL flavors from DICOM to BIDS
+function xASL_test_Flavors_DCM2BIDS(baseDirImport, x)
+%xASL_test_Flavors_DCM2BIDS Convert ASL flavors from DICOM to BIDS
 %
-% FORMAT: xASL_test_BIDSConversion(baseDirImport)
+% FORMAT: xASL_test_Flavors_DCM2BIDS(baseDirImport)
 %
 % INPUT:
 %   baseDirImport    - Directory for import - sourcedata files are in the 'sourcedata' folder (REQUIRED)
@@ -25,13 +25,15 @@ function xASL_test_BIDSConversion(baseDirImport)
 % 3d. Siemens_PCASL_multiTI
 % 4. Convert NII+JSON -> BIDS
 %
-% EXAMPLE: xASL_test_BIDSConversion('mydir/testImport');
+% EXAMPLE: xASL_test_Flavors_DCM2BIDS('mydir/testImport');
 % __________________________________
 % Copyright 2015-2021 ExploreASL
 
 %% 1. Initialization
 % Initialize ExploreASL 
-x = ExploreASL_Initialize;
+if nargin < 2 || isempty(x)
+	x = ExploreASL_Initialize;
+end
 
 % Load the list of the directories
 flavorList = xASL_adm_GetFileList(baseDirImport, [], false, [], true);

--- a/Testing/xASL_test_IntegrationTesting.m
+++ b/Testing/xASL_test_IntegrationTesting.m
@@ -59,7 +59,6 @@ function [TestResults, CheckResults] = xASL_test_IntegrationTesting
 
     % Initialize ExploreASL
     [x] = ExploreASL_Initialize;
-    cd(testConfig.pathTest);
     
     % Clean Up
     clc
@@ -81,12 +80,10 @@ function [TestResults, CheckResults] = xASL_test_IntegrationTesting
     %% Iterate over flavors
     for iFlavor = 1:numel(flavorList)
         % Run individual flavor
-        TestResults(iFlavor) = xASL_test_thisFlavor(testConfig.pathTest, ...
-                                                    fullfile(testConfig.pathTest,'FlavorDatabase'), ...
-                                                    flavorList{iFlavor});
+        TestResults = xASL_test_thisFlavor(testConfig, flavorList{iFlavor});
         % Check logging
-        if isfield(TestResults(iFlavor),'logging')
-            loggingTable = xASL_test_AddLoggingEntryToTable(loggingTable,TestResults(iFlavor).logging);
+        if isfield(TestResults,'logging')
+            loggingTable = xASL_test_AddLoggingEntryToTable(loggingTable,TestResults.logging);
         end
     end
     
@@ -119,8 +116,12 @@ end
 
 
 %% Run individual flavor dataset
-function xFlavor = xASL_test_thisFlavor(testingRoot, databaseRoot, flavorName)
+function xFlavor = xASL_test_thisFlavor(testConfig, flavorName)
 
+    % Get paths
+    testingRoot = testConfig.pathTest;
+    databaseRoot = fullfile(testConfig.pathTest,'FlavorDatabase');
+    
     % Copy flavor
     fprintf('Copy %s...\n', flavorName);
     xASL_Copy(fullfile(databaseRoot,flavorName),fullfile(testingRoot,'FlavorDatabaseTest',flavorName),1);
@@ -136,6 +137,9 @@ function xFlavor = xASL_test_thisFlavor(testingRoot, databaseRoot, flavorName)
     
     % Save JSON
     spm_jsonwrite(fullfile(testingRoot,'FlavorDatabaseTest',flavorName,'dataPar.json'),defaultDataPar);
+    
+    % Remove Matlab paths (independent initialization)
+    xASL_adm_RemoveDirectories(testConfig.pathExploreASL);
 
     % Run test
     try
@@ -218,7 +222,7 @@ function stackText = xASL_test_StackToString(stack)
     end
     
     % Remove initial ' ,'
-    if ~isempty(stackText) && length(stackText>3)
+    if ~isempty(stackText) && length(stackText)>3
         stackText = stackText(3:end);
     end
 

--- a/Testing/xASL_test_IntegrationTesting.m
+++ b/Testing/xASL_test_IntegrationTesting.m
@@ -130,10 +130,8 @@ function xFlavor = xASL_test_thisFlavor(testConfig, flavorName)
     xASL_delete(fullfile(testingRoot,'FlavorDatabaseTest',flavorName,'rawdata'),1);
     
     % Create default dataPar.json
-    defaultDataPar.x.subject_regexp = '^sub-.*$';
     defaultDataPar.x.bUseMNIasDummyStructural = 1; % when no structural data, use ASL-MNI registration
     defaultDataPar.x.Quality = 0; % speed up testing
-    defaultDataPar.x.DELETETEMP = 1;
     
     % Save JSON
     spm_jsonwrite(fullfile(testingRoot,'FlavorDatabaseTest',flavorName,'dataPar.json'),defaultDataPar);

--- a/Testing/xASL_test_IntegrationTesting.m
+++ b/Testing/xASL_test_IntegrationTesting.m
@@ -1,9 +1,11 @@
-function [TestResults, CheckResults] = xASL_test_IntegrationTesting
+function [TestResults, CheckResults, loggingTable] = xASL_test_IntegrationTesting
 %xASL_test_IntegrationTesting Main integration testing script
 %
 % INPUT:        n/a
 %
 % OUTPUT:       TestResults  - Test results struct
+%               CheckResults - Results from rawdata comparison
+%               loggingTable - Combined logging results from ExploreASL runs
 %
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 % DESCRIPTION:  Integration testing script. Run the full pipeline on the flavor datasets using ExploreASL_Master.

--- a/Testing/xASL_test_IntegrationTesting.m
+++ b/Testing/xASL_test_IntegrationTesting.m
@@ -88,7 +88,7 @@ function [TestResults, CheckResults] = xASL_test_IntegrationTesting
     end
     
     %% Write logging table
-    xASL_test_writeLoggingTable(fullfile(testConfig.pathTest,'FlavorDatabaseTest','log.xlsx'), loggingTable);
+    xASL_test_writeLoggingTable(fullfile(testConfig.pathTest,'FlavorDatabaseTest','log'), loggingTable);
     
     %% Compare rawdata
     for iFlavor = 1:numel(flavorList)
@@ -232,12 +232,19 @@ end
 %% Write logging information to XLSX table
 function xASL_test_writeLoggingTable(filePath,logTable)
 
-    % Write file
+    % Write XLSX file
     try
-        writetable(logTable,filePath,'WriteVariableNames',true);
+        writetable(logTable,[filePath '.xlsx'],'WriteVariableNames',true);
     catch ME
         fprintf(2,'Writing log.xlsx failed: %s\n', ME.message);
     end
+    % Write TSV file
+    try
+        xASL_tsvWrite(table2cell(logTable),[filePath '.tsv']);
+    catch ME
+        fprintf(2,'Writing log.tsv failed: %s\n', ME.message);
+    end
+    
 
 end
 


### PR DESCRIPTION
### Linked issue

Check out issue #583

### How to test

- Create a `testConfig.json` in your ExploreASL/Testing directory
- Run: `[TestResults, CheckResults] = xASL_test_IntegrationTesting;`

### Comments

I know this probably doesn't fulfill all requirements yet, but I thought I could show you my initial implementation and how I want to extract the errors/warning in the future. The x struct includes a logging field now (implemented in #588). This includes both errors from the import and from the processing workflow. Those should be written into a `log.xlsx` file. It doesn't catch the various warnings and stuff right now, but the major things are nicely captured.

