### PR TITLE
#612 ExploreASL_Initialize: Backwards compatibility (datPar)

### DIFF
--- a/ExploreASL_Initialize.m
+++ b/ExploreASL_Initialize.m
@@ -588,9 +588,9 @@ function [x, SelectParFile] = ExploreASL_Initialize_checkDatasetRoot_invalid_sta
         [rawdataFolder, ~] = fileparts(x.dir.dataset_description);
         x.dir.DatasetRoot = fileparts(rawdataFolder);
     end
-    if isfield(x.dir,'dataParFile')
+    if isfield(x.dir,'dataPar')
         % We expect the dataPar.json to be within the study root folder
-        [x.dir.DatasetRoot, ~] = fileparts(x.dir.dataParFile);
+        [x.dir.DatasetRoot, ~] = fileparts(x.dir.dataPar);
     end
     
     % Recheck for other files if DatasetRoot is known now


### PR DESCRIPTION
### Linked issue

#612

### How to test

Run the test described in #612 again

### Comments

There was a minor bug in the separate function for the backwards compatibility (wrong fieldname)

