### PR TITLE
#670 ExploreASL_Initialize: Warning in incorrect parameter length

### DIFF
--- a/ExploreASL_Initialize.m
+++ b/ExploreASL_Initialize.m
@@ -336,16 +336,32 @@ function parameters = ExploreASL_Initialize_convertParsedInput(parameters)
     if ischar(parameters.nWorkers),         parameters.nWorkers = str2num(parameters.nWorkers);             end
     
     % Check length of arrays (single digit input)
-    if length(parameters.ImportModules)<4
-        parameters.ImportModules = [parameters.ImportModules(1),...
-                                    parameters.ImportModules(1),...
-                                    parameters.ImportModules(1),...
-                                    parameters.ImportModules(1)];
+    if length(parameters.ImportModules)==1
+		% If a single value is given, then copy it to all submodules
+		parameters.ImportModules(1:4) = parameters.ImportModules(1);
+	elseif length(parameters.ImportModules)<4
+		% Convert to a row vector
+		parameters.ImportModules = parameters.ImportModules(:)';
+		
+		% Fill in the missing fields with zeros
+		parameters.ImportModules(length(parameters.ImportModules)+1:4) = 0;
+		
+		% Issue a warning
+		warning('Incorrect length of the ImportModules parameter, missing submodules set to zero: %s\n',num2str(parameters.ImportModules));
+        
     end
-    if length(parameters.ProcessModules)<3
-        parameters.ProcessModules = [parameters.ProcessModules(1),...
-                                     parameters.ProcessModules(1),...
-                                     parameters.ProcessModules(1)];
+    if length(parameters.ProcessModules)==1
+		% If a single value is given, then copy it to all submodules
+		parameters.ProcessModules(1:3) = parameters.ProcessModules(1);
+	elseif length(parameters.ProcessModules)<3
+		% Convert to a row vector
+		parameters.ProcessModules = parameters.ProcessModules(:)';
+		
+		% Fill in the missing fields with zeros
+		parameters.ProcessModules(length(parameters.ProcessModules)+1:3) = 0;
+		
+		% Issue a warning
+		warning('Incorrect length of the ProcessModules parameter, missing submodules set to zero: %s\n',num2str(parameters.ProcessModules));
     end
     
     % Make it impossible to set bPause to true in deployed mode

--- a/ExploreASL_Initialize.m
+++ b/ExploreASL_Initialize.m
@@ -337,31 +337,26 @@ function parameters = ExploreASL_Initialize_convertParsedInput(parameters)
     
     % Check length of arrays (single digit input)
     if length(parameters.ImportModules)==1
-		% If a single value is given, then copy it to all submodules
-		parameters.ImportModules(1:4) = parameters.ImportModules(1);
-	elseif length(parameters.ImportModules)<4
-		% Convert to a row vector
-		parameters.ImportModules = parameters.ImportModules(:)';
-		
-		% Fill in the missing fields with zeros
-		parameters.ImportModules(length(parameters.ImportModules)+1:4) = 0;
-		
-		% Issue a warning
-		warning('Incorrect length of the ImportModules parameter, missing submodules set to zero: %s\n',num2str(parameters.ImportModules));
-        
+        % If a single value is given, then copy it to all submodules
+        parameters.ImportModules(1:4) = parameters.ImportModules(1);
+    elseif length(parameters.ImportModules)<4
+        % Convert to a row vector
+        parameters.ImportModules = parameters.ImportModules(:)';
+        % Fill in the missing fields with zeros
+        parameters.ImportModules(length(parameters.ImportModules)+1:4) = 0;
+        % Issue a warning
+        warning('Incorrect length of the ImportModules parameter, missing submodules set to zero: %s\n',num2str(parameters.ImportModules));
     end
     if length(parameters.ProcessModules)==1
-		% If a single value is given, then copy it to all submodules
-		parameters.ProcessModules(1:3) = parameters.ProcessModules(1);
-	elseif length(parameters.ProcessModules)<3
-		% Convert to a row vector
-		parameters.ProcessModules = parameters.ProcessModules(:)';
-		
-		% Fill in the missing fields with zeros
-		parameters.ProcessModules(length(parameters.ProcessModules)+1:3) = 0;
-		
-		% Issue a warning
-		warning('Incorrect length of the ProcessModules parameter, missing submodules set to zero: %s\n',num2str(parameters.ProcessModules));
+        % If a single value is given, then copy it to all submodules
+        parameters.ProcessModules(1:3) = parameters.ProcessModules(1);
+    elseif length(parameters.ProcessModules)<3
+        % Convert to a row vector
+        parameters.ProcessModules = parameters.ProcessModules(:)';
+        % Fill in the missing fields with zeros
+        parameters.ProcessModules(length(parameters.ProcessModules)+1:3) = 0;
+        % Issue a warning
+        warning('Incorrect length of the ProcessModules parameter, missing submodules set to zero: %s\n',num2str(parameters.ProcessModules));
     end
     
     % Make it impossible to set bPause to true in deployed mode


### PR DESCRIPTION
### Linked issue

#670 

### How to test

Run with single value of ProcessModule and ImportModule parameters, complete length and incomplete length. All should work now.

