### PR TITLE
Fixes #850 xASL_wrp_RealingASL: field checks

### DIFF
--- a/Functions/xASL_bids_CompareStructures.m
+++ b/Functions/xASL_bids_CompareStructures.m
@@ -136,7 +136,9 @@ end
 function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable,results,datasetA,datasetB)
 
     % Go through missing folders
-    if size(results.(datasetA).missingFolders,1)>0 && ~isempty(results.(datasetA).missingFolders{1})
+    if size(results.(datasetA).missingFolders,1)>0 && ...
+       size(results.(datasetA).missingFolders,2)>0 && ...
+            ~isempty(results.(datasetA).missingFolders{1})
         for iElement=1:size(results.(datasetA).missingFolders,1)
             dataset = cellstr(datasetA);
             name = cellstr('Missing folder');
@@ -144,7 +146,9 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
-    if size(results.(datasetB).missingFolders,1)>0 && ~isempty(results.(datasetB).missingFolders{1})
+    if size(results.(datasetB).missingFolders,1)>0 && ...
+       size(results.(datasetB).missingFolders,2)>0 && ...
+            ~isempty(results.(datasetB).missingFolders{1})
         for iElement=1:size(results.(datasetB).missingFolders,1)
             dataset = cellstr(datasetB);
             name = cellstr('Missing folder');
@@ -154,7 +158,9 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
     end
 
     % Go through missing files
-    if size(results.(datasetA).missingFiles,1)>0 && ~isempty(results.(datasetA).missingFiles{1})
+    if size(results.(datasetA).missingFiles,1)>0 && ...
+       size(results.(datasetA).missingFiles,2)>0 && ...
+            ~isempty(results.(datasetA).missingFiles{1})
         for iElement=1:size(results.(datasetA).missingFiles,1)
             dataset = cellstr(datasetA);
             name = cellstr('Missing file');
@@ -162,7 +168,9 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
-    if size(results.(datasetB).missingFiles,1)>0 && ~isempty(results.(datasetB).missingFiles{1})
+    if size(results.(datasetB).missingFiles,1)>0 && ...
+       size(results.(datasetB).missingFiles,2)>0 && ...
+            ~isempty(results.(datasetB).missingFiles{1})
         for iElement=1:size(results.(datasetB).missingFiles,1)
             dataset = cellstr(datasetB);
             name = cellstr('Missing file');

--- a/Functions/xASL_bids_CompareStructures.m
+++ b/Functions/xASL_bids_CompareStructures.m
@@ -138,19 +138,19 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
     % Go through missing folders
     if numel(results.(datasetA).missingFolders)>0 && ...
             ~isempty(results.(datasetA).missingFolders{1})
-        for iElement=1:size(results.(datasetA).missingFolders,1)
+        for iElement=1:numel(results.(datasetA).missingFolders)
             dataset = cellstr(datasetA);
             name = cellstr('Missing folder');
-            message = cellstr(results.(datasetA).missingFolders{iElement,1});
+            message = cellstr(results.(datasetA).missingFolders{iElement});
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
     if numel(results.(datasetB).missingFolders)>0 && ...
             ~isempty(results.(datasetB).missingFolders{1})
-        for iElement=1:size(results.(datasetB).missingFolders,1)
+        for iElement=1:numel(results.(datasetB).missingFolders)
             dataset = cellstr(datasetB);
             name = cellstr('Missing folder');
-            message = cellstr(results.(datasetB).missingFolders{iElement,1});
+            message = cellstr(results.(datasetB).missingFolders{iElement});
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
@@ -158,16 +158,16 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
     % Go through missing files
     if numel(results.(datasetA).missingFiles)>0 && ...
             ~isempty(results.(datasetA).missingFiles{1})
-        for iElement=1:size(results.(datasetA).missingFiles,1)
+        for iElement=1:numel(results.(datasetA).missingFiles)
             dataset = cellstr(datasetA);
             name = cellstr('Missing file');
-            message = cellstr(results.(datasetA).missingFiles{iElement,1});
+            message = cellstr(results.(datasetA).missingFiles{iElement});
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
     if numel(results.(datasetB).missingFiles)>0 && ...
             ~isempty(results.(datasetB).missingFiles{1})
-        for iElement=1:size(results.(datasetB).missingFiles,1)
+        for iElement=1:numel(results.(datasetB).missingFiles)
             dataset = cellstr(datasetB);
             name = cellstr('Missing file');
             message = cellstr(results.(datasetB).missingFiles{iElement,1});
@@ -177,10 +177,10 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
 
     % Go through differences
     if ~isempty(results.differences{1})
-        for iElement=1:size(results.differences,1)
+        for iElement=1:numel(results.differences)
             dataset = cellstr('Both');
             name = cellstr('Different file content');
-            message = cellstr(results.differences{iElement,1});
+            message = cellstr(results.differences{iElement});
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end

--- a/Functions/xASL_bids_CompareStructures.m
+++ b/Functions/xASL_bids_CompareStructures.m
@@ -136,8 +136,7 @@ end
 function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable,results,datasetA,datasetB)
 
     % Go through missing folders
-    if size(results.(datasetA).missingFolders,1)>0 && ...
-       size(results.(datasetA).missingFolders,2)>0 && ...
+    if numel(results.(datasetA).missingFolders)>0 && ...
             ~isempty(results.(datasetA).missingFolders{1})
         for iElement=1:size(results.(datasetA).missingFolders,1)
             dataset = cellstr(datasetA);
@@ -146,8 +145,7 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
-    if size(results.(datasetB).missingFolders,1)>0 && ...
-       size(results.(datasetB).missingFolders,2)>0 && ...
+    if numel(results.(datasetB).missingFolders)>0 && ...
             ~isempty(results.(datasetB).missingFolders{1})
         for iElement=1:size(results.(datasetB).missingFolders,1)
             dataset = cellstr(datasetB);
@@ -158,8 +156,7 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
     end
 
     % Go through missing files
-    if size(results.(datasetA).missingFiles,1)>0 && ...
-       size(results.(datasetA).missingFiles,2)>0 && ...
+    if numel(results.(datasetA).missingFiles)>0 && ...
             ~isempty(results.(datasetA).missingFiles{1})
         for iElement=1:size(results.(datasetA).missingFiles,1)
             dataset = cellstr(datasetA);
@@ -168,8 +165,7 @@ function reportTable = xASL_bids_CompareStructures_AddEntriesToTable(reportTable
             reportTable = xASL_bids_CompareStructures_AddTableRow(reportTable,dataset,name,message);
         end
     end
-    if size(results.(datasetB).missingFiles,1)>0 && ...
-       size(results.(datasetB).missingFiles,2)>0 && ...
+    if numel(results.(datasetB).missingFiles)>0 && ...
             ~isempty(results.(datasetB).missingFiles{1})
         for iElement=1:size(results.(datasetB).missingFiles,1)
             dataset = cellstr(datasetB);

--- a/Modules/SubModule_ASL/xASL_wrp_RealignASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_RealignASL.m
@@ -123,8 +123,8 @@ xASL_delete(rpfile);
 %     end  
     
 if nFrames>2 && bSubtraction && ...
-    isfield(x.Q,'Initial_PLD') && isfield(x,'EchoTime') && isfield(x.modules.asl,'HadamardType') && ...
-    (numel(unique(x.Q.Initial_PLD))>1 || numel(unique(x.EchoTime))>1 || x.modules.asl.HadamardType~=0)
+    isfield(x.Q,'Initial_PLD') && isfield(x,'EchoTime') && isfield(x.modules.asl,'TimeEncodedMatrixType') && ...
+    (numel(unique(x.Q.Initial_PLD))>1 || numel(unique(x.EchoTime))>1 || x.modules.asl.TimeEncodedMatrixType~=0)
 
     % Multi-PLD, Multi-TE or Hadamard
     spm_realign(spm_vol(InputPath),flags,false);

--- a/Modules/SubModule_ASL/xASL_wrp_RealignASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_RealignASL.m
@@ -120,12 +120,15 @@ xASL_delete(rpfile);
 %         MotionFirstTEs=load(rpfile);
 %         MotionAllTEs=repelem(MotionFirstTEs(:,:),NumTEs,1); 
 %         save('rp_ASL4D.txt','MotionAllTEs','-ascii')
-%     end  
-    
-if nFrames>2 && bSubtraction && ...
-    isfield(x.Q,'Initial_PLD') && isfield(x,'EchoTime') && isfield(x.modules.asl,'TimeEncodedMatrixType') && ...
-    (numel(unique(x.Q.Initial_PLD))>1 || numel(unique(x.EchoTime))>1 || x.modules.asl.TimeEncodedMatrixType~=0)
+%     end
 
+% Define conditions for motion correction in multi-PLD, multi-TE and Hadamard subjects
+conditionMultiPLD = isfield(x.Q,'Initial_PLD') && (numel(unique(x.Q.Initial_PLD))>1);
+conditionMultiTE = isfield(x,'EchoTime') && (numel(unique(x.EchoTime))>1);
+conditionHadamard = isfield(x.modules.asl,'TimeEncodedMatrixType') && (x.modules.asl.TimeEncodedMatrixType~=0);
+
+% Run motion correction for corresponding case
+if nFrames>2 && bSubtraction && (conditionMultiPLD  ||  conditionMultiTE  || conditionHadamard)
     % Multi-PLD, Multi-TE or Hadamard
     spm_realign(spm_vol(InputPath),flags,false);
     

--- a/Modules/SubModule_ASL/xASL_wrp_RealignASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_RealignASL.m
@@ -122,7 +122,11 @@ xASL_delete(rpfile);
 %         save('rp_ASL4D.txt','MotionAllTEs','-ascii')
 %     end  
     
-if nFrames>2 && bSubtraction && (numel(unique(x.Q.Initial_PLD))>1 || numel(unique(x.EchoTime))>1 || x.modules.asl.HadamardType~=0) %multiPLD or multiTE or Hadamard
+if nFrames>2 && bSubtraction && ...
+    isfield(x.Q,'Initial_PLD') && isfield(x,'EchoTime') && isfield(x.modules.asl,'HadamardType') && ...
+    (numel(unique(x.Q.Initial_PLD))>1 || numel(unique(x.EchoTime))>1 || x.modules.asl.HadamardType~=0)
+
+    % Multi-PLD, Multi-TE or Hadamard
     spm_realign(spm_vol(InputPath),flags,false);
     
 elseif nFrames>2 && bSubtraction

--- a/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
@@ -230,15 +230,13 @@ for iSpace=1:2
         warning('Odd number of control-label pairs, skipping');
         return;
         
-        % Decoding of TimeEncoded data ===================
-    elseif x.modules.asl.bTimeEncoded 
-            ASL_im = xASL_im_HadamardDecoding(x.P.Path_rdespiked_ASL4D, x.modules.asl, x.TimeEncodedEchoTimes); % Nifti is saved inside the function
-        % =============================================
+    elseif isfield(x.modules.asl,'bTimeEncoded') && x.modules.asl.bTimeEncoded
+        % Decoding of TimeEncoded data (Nifti is saved inside the function)
+        ASL_im = xASL_im_HadamardDecoding(x.P.Path_rdespiked_ASL4D, x.modules.asl, x.TimeEncodedEchoTimes);
         
         % Save PWI4D
         fprintf('%s\n', [PathPWI4D{iSpace} ', ']);
         xASL_io_SaveNifti(PathASL{iSpace}, PathPWI4D{iSpace}, ASL_im, 32, false);
-        
         
     else
         % Paired subtraction

--- a/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_ResampleASL.m
@@ -130,7 +130,8 @@ end
 %% ------------------------------------------------------------------------------------------
 % 6. Create mean control image, if available, in native & standard space
 if  nVolumes>1    
-    if x.modules.asl.bTimeEncoded % ===== Here we should just configure the mean control (first volume)==== %
+    if isfield(x.modules.asl,'bTimeEncoded') && x.modules.asl.bTimeEncoded 
+        % Here we should just configure the mean control (first volume)
         Im=xASL_io_Nifti2Im(x.P.Path_rdespiked_ASL4D);   
         ControlIm = Im(:,:,:,1);    
         xASL_io_SaveNifti(x.P.Path_rdespiked_ASL4D, x.P.Path_mean_control, ControlIm, [], 0);
@@ -141,7 +142,8 @@ if  nVolumes>1
         xASL_io_SaveNifti(x.P.Path_rdespiked_ASL4D, x.P.Path_mean_control, IM_mean, [], 0);
     end
     % Transform mean control to standard space
-    if exist(x.P.Path_mean_PWI_Clipped_sn_mat, 'file') % Backwards compatability, and also needed for the Affine+DCT co-registration of ASL-T1w
+    if exist(x.P.Path_mean_PWI_Clipped_sn_mat, 'file') 
+        % Backwards compatability, and also needed for the Affine+DCT co-registration of ASL-T1w
         AffineTransfPath = x.P.Path_mean_PWI_Clipped_sn_mat;
     else
         AffineTransfPath = [];

--- a/Testing/UnitTests/xASL_ut_function_xASL_bids_CompareStructures.m
+++ b/Testing/UnitTests/xASL_ut_function_xASL_bids_CompareStructures.m
@@ -276,14 +276,16 @@ end
 
 % Check missing folders
 if isfield(results,'datasetA') && isfield(results.datasetA,'missingFolders')
-    if isempty(regexp(results.datasetA.missingFolders{1},'SubFolder1B', 'once'))
+    if numel(results.datasetA.missingFolders)>0 && ...
+       isempty(regexp(results.datasetA.missingFolders{1},'SubFolder1B', 'once'))
         testCondition = false;
     end
 else
     testCondition = false;
 end
 if isfield(results,'datasetB') && isfield(results.datasetB,'missingFolders')
-    if isempty(regexp(results.datasetB.missingFolders{1},'SubFolder1A', 'once'))
+    if numel(results.datasetB.missingFolders)>0 && ...
+       isempty(regexp(results.datasetB.missingFolders{1},'SubFolder1A', 'once'))
         testCondition = false;
     end
 else


### PR DESCRIPTION
### Linked issue

Check out #850

### How to test

Develop without this fix should basically crash for almost every non-Hadamard dataset. Just do some basic testing of the ASL module using the test dataset. Alternatively you can always run the 10 test datasets, but that's probably overkill for such a small change.

### Comments

@BeatrizPadrela: Okay, same here as with https://github.com/ExploreASL/ExploreASL/pull/849, please check if everything works correctly. If yes, then approve & move it to @jan-petr's bucket.

