### PR TITLE
Closes #893 xASL_spm_admin: Allow cell input

### DIFF
--- a/External/SPMmodified/xASL/xASL_spm_admin.m
+++ b/External/SPMmodified/xASL/xASL_spm_admin.m
@@ -27,9 +27,12 @@ function [pathOut] = xASL_spm_admin(pathIn, bPadComma1)
 
     if nargin<1 || isempty(pathIn)
         error('Too few input arguments');
-    elseif ~ischar(pathIn)
+    elseif iscell(pathIn) && numel(pathIn)==1
+        pathIn = pathIn{1};
+    end
+    if ~ischar(pathIn)
         error('pathIn should be a char array');
-    end    
+    end
 
     if nargin<2 || isempty(bPadComma1)
         bPadComma1 = true; % default


### PR DESCRIPTION
### Linked issue

Closes #893

### How to test

Just run ExploreASL, any SPM-related function uses this `xASL_spm_admin`.

### Comments

Optional: add helpful comments for the reviewers here

