### PR TITLE
Closes #841 Import zipped files

### DIFF
--- a/External/SPMmodified/xASL/xASL_delete.m
+++ b/External/SPMmodified/xASL/xASL_delete.m
@@ -1,7 +1,7 @@
 function xASL_delete(InputPath, bFolderContent)
 % Deletes the file given in the InputPath. For NIFTII file, delete also the GZ version
 %
-% FORMAT: xASL_delete(InputPath)
+% FORMAT: xASL_delete(InputPath, bFolderContent)
 %
 % INPUT:
 %   InputPath           - path to the file to be deleted (REQUIRED)
@@ -9,16 +9,18 @@ function xASL_delete(InputPath, bFolderContent)
 %                         InputPath to folder) (OPTIONAL, DEFAULT = false)
 %   
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
-% DESCRIPTION: Delete the file in the given path. If a NIFTI file with extension '.nii' or '.nii.gz' is given,
-%              Then delete both the .nii and .nii.gz files.
+% DESCRIPTION: Delete the file in the given path. If a NIFTI file with
+%              extension '.nii' or '.nii.gz' is given, then delete both the
+%              .nii and .nii.gz files. Allows deleting folder including its contents.
+%
 % EXAMPLE: xASL_delete('/path/file.nii');
+%
 % -----------------------------------------------------------------------------------------------------------------------------------------------------
 %
 % __________________________________
-% Copyright 2015-2019 ExploreASL
-%
-% 2019-09-29 HJ allow deleting folder including its contents
+% Copyright 2015-2021 (c) ExploreASL
 
+% Check arguments
 if nargin<2 || isempty(bFolderContent)
     bFolderContent = false;
 elseif ischar(bFolderContent) || ~(bFolderContent==0 || bFolderContent==1)

--- a/Functions/xASL_bids_Dicom2JSON.m
+++ b/Functions/xASL_bids_Dicom2JSON.m
@@ -111,41 +111,16 @@ t_parms = cell(1,1);
 c_all_parms = cell(1,1);
 c_first_parms = cell(1,1);
 
+% More defaults
+parms = cell(1,1);
+instanceNumberList = [];
+seriesNumberList = [];
+
 %% ----------------------------------------------------------------------------------
 % 3. Recreate the parameter file from raw data
 % ----------------------------------------------------------------------------------
 for iJSON = 1:length(pathJSON)
-    if ~isempty(pathJSON{iJSON})
-        
-        % Print file name
-        if isfield(imPar,'TempRoot') && ~isempty(strfind(pathJSON{iJSON},imPar.TempRoot))
-            % Relative path
-            printFileName = pathJSON{iJSON}(length(imPar.TempRoot)+1:end);
-        else
-            % Absolute path
-            printFileName = pathJSON{iJSON};
-        end
-        
-        % Print name
-        if imPar.bVerbose; fprintf('Recreating parameter file: %s   \n',printFileName); end
-        
-        % Make a list of the instanceNumbers
-        tmpJSON = spm_jsonread(pathJSON{iJSON});
-        
-        % Check instance & series number
-        if isfield(tmpJSON,'InstanceNumber')
-            instanceNumberList(iJSON) = xASL_str2num(tmpJSON.InstanceNumber);
-        else
-            instanceNumberList(iJSON) = 0;
-        end
-        if isfield(tmpJSON,'SeriesNumber')
-            seriesNumberList(iJSON) = xASL_str2num(tmpJSON.SeriesNumber);
-        else
-            seriesNumberList(iJSON) = 0;
-        end
-    end
-    % Create a cell of parms
-    parms{iJSON} = struct();
+    [parms,instanceNumberList,seriesNumberList] = xASL_bids_Dicom2JSON_ProcessJSON(parms,instanceNumberList,seriesNumberList,pathJSON,iJSON,imPar);
 end
 
 % Reoder JSONs by increasing seriesNumber and instanceNumber to allow easy categorizing to the correct range.
@@ -253,6 +228,7 @@ if ~isempty(FileList)
         
         
     end
+    fprintf('\n');
     
     
     
@@ -741,5 +717,45 @@ function [t_parms,c_all_parms,c_first_parms,bManufacturer,dcmfields,parmsIndex,i
     [t_parms,c_all_parms,c_first_parms] = xASL_bids_Dicom2JSON_ObtainParameters(t_parms,c_all_parms,c_first_parms,temp,dcmfields,DcmParDefaults,DcmComplexFieldAll,DcmComplexFieldFirst,parmsIndex,iMrFile);
 
 
+end
+
+
+%% Process JSON
+function [parms,instanceNumberList,seriesNumberList] = xASL_bids_Dicom2JSON_ProcessJSON(parms,instanceNumberList,seriesNumberList,pathJSON,iJSON,imPar)
+    
+    if ~isempty(pathJSON{iJSON})
+        
+        % Print file name
+        if isfield(imPar,'TempRoot') && ~isempty(strfind(pathJSON{iJSON},imPar.TempRoot))
+            % Relative path
+            printFileName = pathJSON{iJSON}(length(imPar.TempRoot)+1:end);
+        else
+            % Absolute path
+            printFileName = pathJSON{iJSON};
+        end
+        
+        % Print name
+        if imPar.bVerbose
+            fprintf('Recreating parameter file: %s   \n',printFileName);
+        end
+        
+        % Make a list of the instanceNumbers
+        tmpJSON = spm_jsonread(pathJSON{iJSON});
+        
+        % Check instance & series number
+        if isfield(tmpJSON,'InstanceNumber')
+            instanceNumberList(iJSON) = xASL_str2num(tmpJSON.InstanceNumber);
+        else
+            instanceNumberList(iJSON) = 0;
+        end
+        if isfield(tmpJSON,'SeriesNumber')
+            seriesNumberList(iJSON) = xASL_str2num(tmpJSON.SeriesNumber);
+        else
+            seriesNumberList(iJSON) = 0;
+        end
+    end
+    % Create a cell of parms
+    parms{iJSON} = struct();
+    
 end
 

--- a/Functions/xASL_bids_Dicom2JSON.m
+++ b/Functions/xASL_bids_Dicom2JSON.m
@@ -375,21 +375,7 @@ if ~isempty(FileList)
         
         
         %% First remove non-finite values
-        if  isfield(parms{parmsIndex},'EchoTime')
-            parms{parmsIndex}.EchoTime              = parms{parmsIndex}.EchoTime(isfinite(parms{parmsIndex}.EchoTime));
-        end
-        if  isfield(parms{parmsIndex},'RepetitionTime')
-            parms{parmsIndex}.RepetitionTime        = parms{parmsIndex}.RepetitionTime(isfinite(parms{parmsIndex}.RepetitionTime));
-        end
-        if  isfield(parms{parmsIndex},'MRScaleSlope')
-            parms{parmsIndex}.MRScaleSlope          = parms{parmsIndex}.MRScaleSlope(isfinite(parms{parmsIndex}.MRScaleSlope));
-        end
-        if  isfield(parms{parmsIndex},'RescaleSlopeOriginal')
-            parms{parmsIndex}.RescaleSlopeOriginal  = parms{parmsIndex}.RescaleSlopeOriginal(isfinite(parms{parmsIndex}.RescaleSlopeOriginal));
-        end
-        if  isfield(parms{parmsIndex},'RescaleIntercept')
-            parms{parmsIndex}.RescaleIntercept      = parms{parmsIndex}.RescaleIntercept(isfinite(parms{parmsIndex}.RescaleIntercept));
-        end
+        [parms] = xASL_bids_Dicom2JSON_RemoveNonFiniteValues(parms,parmsIndex);
         
         % In case more than one value is given, then keep only the value that is not equal to 1. Or set to 1 if all are 1
         parmNameToCheck = {'MRScaleSlope','RescaleSlopeOriginal','RescaleSlope','RWVSlope'};
@@ -704,6 +690,28 @@ function [parms] = xASL_bids_Dicom2JSON_TopUpParameters(parms,parmsIndex,bManufa
             end
         otherwise
             % skip
+    end
+
+end
+
+
+%% First remove non-finite values
+function [parms] = xASL_bids_Dicom2JSON_RemoveNonFiniteValues(parms,parmsIndex)
+
+    if  isfield(parms{parmsIndex},'EchoTime')
+        parms{parmsIndex}.EchoTime              = parms{parmsIndex}.EchoTime(isfinite(parms{parmsIndex}.EchoTime));
+    end
+    if  isfield(parms{parmsIndex},'RepetitionTime')
+        parms{parmsIndex}.RepetitionTime        = parms{parmsIndex}.RepetitionTime(isfinite(parms{parmsIndex}.RepetitionTime));
+    end
+    if  isfield(parms{parmsIndex},'MRScaleSlope')
+        parms{parmsIndex}.MRScaleSlope          = parms{parmsIndex}.MRScaleSlope(isfinite(parms{parmsIndex}.MRScaleSlope));
+    end
+    if  isfield(parms{parmsIndex},'RescaleSlopeOriginal')
+        parms{parmsIndex}.RescaleSlopeOriginal  = parms{parmsIndex}.RescaleSlopeOriginal(isfinite(parms{parmsIndex}.RescaleSlopeOriginal));
+    end
+    if  isfield(parms{parmsIndex},'RescaleIntercept')
+        parms{parmsIndex}.RescaleIntercept      = parms{parmsIndex}.RescaleIntercept(isfinite(parms{parmsIndex}.RescaleIntercept));
     end
 
 end

--- a/Functions/xASL_bids_Dicom2JSON.m
+++ b/Functions/xASL_bids_Dicom2JSON.m
@@ -416,20 +416,31 @@ function [parms, pathDcmDictOut] = xASL_bids_Dicom2JSON(imPar, pathIn, pathJSON,
 				% -----------------------------------------------------------------------------
 				
 				% Limit AcquisitionTime to one value
-				if  isfield(t_parms{parmsIndex},'AcquisitionTime')
-					for iL=1:length(t_parms{parmsIndex})
-						t_parms{parmsIndex}(iL).AcquisitionTime = xASL_str2num(t_parms{parmsIndex}(iL).AcquisitionTime);
-					end
-					
-					if length(t_parms{parmsIndex})>1
-						if imPar.bVerbose; fprintf('%s\n','Parameter AcquisitionTime has multiple values:'); end
-						%                     t_parms{parmsIndex}.AcquisitionTime
-						if imPar.bVerbose; fprintf('%s\n','using minumum value:'); end
-						%                     t_parms{parmsIndex}.AcquisitionTime = min(t_parms{parmsIndex}.AcquisitionTime)
-						tempAcquisitionTime = t_parms{parmsIndex}(1).AcquisitionTime;
-						t_parms{parmsIndex} = rmfield(t_parms{parmsIndex},'AcquisitionTime');
-						t_parms{parmsIndex}(1).AcquisitionTime = tempAcquisitionTime;
-					end
+                if parmsIndex>numel(t_parms)
+                    % This statement catches the cases where we iterate out of valid ranges of the t_parms struct. Right now I
+                    % mostly saw that bug during the import using bMatchDirectory = false! We probabaly determine the index wrong there!
+                    warning('Dicom to JSON: Invalid index for t_parms...');
+                    return
+                else
+                    if  isfield(t_parms{parmsIndex},'AcquisitionTime')
+                        for iL=1:length(t_parms{parmsIndex})
+                            t_parms{parmsIndex}(iL).AcquisitionTime = xASL_str2num(t_parms{parmsIndex}(iL).AcquisitionTime);
+                        end
+
+                        if length(t_parms{parmsIndex})>1
+                            if imPar.bVerbose
+                                fprintf('Parameter AcquisitionTime has multiple values: \n');
+                                disp(t_parms{parmsIndex}.AcquisitionTime);
+                            end
+                            if imPar.bVerbose
+                                fprintf('Using minumum value: \n');
+                                % t_parms{parmsIndex}.AcquisitionTime = min(t_parms{parmsIndex}.AcquisitionTime)
+                            end
+                            tempAcquisitionTime = t_parms{parmsIndex}(1).AcquisitionTime;
+                            t_parms{parmsIndex} = rmfield(t_parms{parmsIndex},'AcquisitionTime');
+                            t_parms{parmsIndex}(1).AcquisitionTime = tempAcquisitionTime;
+                        end
+                    end
                 end
 				
                 % Convert number to time format (check that current struct exists / is not empty)

--- a/Functions/xASL_bids_Dicom2JSON.m
+++ b/Functions/xASL_bids_Dicom2JSON.m
@@ -324,55 +324,14 @@ function [parms, pathDcmDictOut] = xASL_bids_Dicom2JSON(imPar, pathIn, pathJSON,
             end
 			
 			
-			% Do this only once, and do not reset the manufacturer for other files (assume the same is for all files within the directory)
+			%% Do this only once, and do not reset the manufacturer for other files (assume the same is for all files within the directory)
             [bManufacturer,dcmfields] = xASL_bids_Dicom2JSON_IdentifyManufacturer(temp,dcmfields,DcmFieldList,bManufacturer);
+            
+            
+            %% Obtain the selected DICOM parameters from the header
+            [t_parms,c_all_parms,c_first_parms] = xASL_bids_Dicom2JSON_ObtainParameters(temp,dcmfields,DcmParDefaults,DcmComplexFieldAll,DcmComplexFieldFirst,parmsIndex,iMrFile);
 			
-            %% -----------------------------------------------------------------------------
-            % Obtain the selected DICOM parameters from the header
-            % Write the new parameter to the list (or put the default value)
-            % -----------------------------------------------------------------------------
-            for iField=1:length(dcmfields)
-                fieldname = dcmfields{iField};
-                
-                % Extract value of current field
-                if  isfield(temp, fieldname)
-                    thevalue = temp.(fieldname);
-                    thevalue = thevalue(~isnan(thevalue));
-                else
-                    thevalue = [];
-                end
-                
-                % Convert string-numbers to numbers if necessary
-                if ~isempty(thevalue)
-                    if length(xASL_str2num(thevalue))>1
-                        tmpTheValue = nonzeros(thevalue);
-                        tmpTheValue = tmpTheValue(1);
-                    else
-                        tmpTheValue = thevalue;
-                    end
-                    t_parms{parmsIndex}.(fieldname)(iMrFile) = xASL_str2num(tmpTheValue);
-                else
-                    % if imPar.bVerbose
-                        % if iMrFile==1, fprintf('%s\n',['Parameter ' fieldname ' not found, default used']); end
-                    % end
-                    t_parms{parmsIndex}.(fieldname)(iMrFile) = DcmParDefaults.(fieldname);
-                end
-            end
 			
-			c_all_parms{parmsIndex} = struct;
-			% The more complex fields - strings and arrays are saved in cell
-			for iField=1:length(DcmComplexFieldAll)
-				if isfield(temp,DcmComplexFieldAll{iField}) && ~isempty(temp.(DcmComplexFieldAll{iField}))
-					c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField}){iMrFile} = temp.(DcmComplexFieldAll{iField});
-				end
-			end
-			
-			c_first_parms{parmsIndex} = struct;
-			for iField=1:length(DcmComplexFieldFirst)
-				if isfield(temp,DcmComplexFieldFirst{iField}) && ~isempty(temp.(DcmComplexFieldFirst{iField}))
-					c_first_parms{parmsIndex}.(DcmComplexFieldFirst{iField}) = temp.(DcmComplexFieldFirst{iField});
-				end
-			end
 		end
 		for indexInstance = 1:length(parms)
 			if instanceNumberList(indexInstance) > 0
@@ -675,3 +634,57 @@ function [bManufacturer,dcmfields] = xASL_bids_Dicom2JSON_IdentifyManufacturer(t
     end
 
 end
+
+
+%% Obtain parameters
+function [t_parms,c_all_parms,c_first_parms] = xASL_bids_Dicom2JSON_ObtainParameters(temp,dcmfields,DcmParDefaults,DcmComplexFieldAll,DcmComplexFieldFirst,parmsIndex,iMrFile)
+
+    % Obtain the selected DICOM parameters from the header
+    % Write the new parameter to the list (or put the default value)
+
+    for iField=1:length(dcmfields)
+        fieldname = dcmfields{iField};
+
+        % Extract value of current field
+        if  isfield(temp, fieldname)
+            thevalue = temp.(fieldname);
+            thevalue = thevalue(~isnan(thevalue));
+        else
+            thevalue = [];
+        end
+
+        % Convert string-numbers to numbers if necessary
+        if ~isempty(thevalue)
+            if length(xASL_str2num(thevalue))>1
+                tmpTheValue = nonzeros(thevalue);
+                tmpTheValue = tmpTheValue(1);
+            else
+                tmpTheValue = thevalue;
+            end
+            t_parms{parmsIndex}.(fieldname)(iMrFile) = xASL_str2num(tmpTheValue);
+        else
+            % if imPar.bVerbose
+            % if iMrFile==1, fprintf('%s\n',['Parameter ' fieldname ' not found, default used']); end
+            % end
+            t_parms{parmsIndex}.(fieldname)(iMrFile) = DcmParDefaults.(fieldname);
+        end
+    end
+    
+    
+    c_all_parms{parmsIndex} = struct;
+    % The more complex fields - strings and arrays are saved in cell
+    for iField=1:length(DcmComplexFieldAll)
+        if isfield(temp,DcmComplexFieldAll{iField}) && ~isempty(temp.(DcmComplexFieldAll{iField}))
+            c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField}){iMrFile} = temp.(DcmComplexFieldAll{iField});
+        end
+    end
+    
+    c_first_parms{parmsIndex} = struct;
+    for iField=1:length(DcmComplexFieldFirst)
+        if isfield(temp,DcmComplexFieldFirst{iField}) && ~isempty(temp.(DcmComplexFieldFirst{iField}))
+            c_first_parms{parmsIndex}.(DcmComplexFieldFirst{iField}) = temp.(DcmComplexFieldFirst{iField});
+        end
+    end
+
+end
+

--- a/Functions/xASL_bids_Dicom2JSON.m
+++ b/Functions/xASL_bids_Dicom2JSON.m
@@ -260,27 +260,8 @@ if ~isempty(FileList)
         end
         
         % The more complex fields - strings and arrays are saved in cell
-        for iField=1:length(DcmComplexFieldAll)
-            if isfield(c_all_parms{parmsIndex},DcmComplexFieldAll{iField})
-                listEmptyFields = find(cellfun(@isempty,c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField})));
-                if ~isempty(listEmptyFields)
-                    fprintf('\nField %s contains empty fields, skipping... \n',DcmComplexFieldAll{iField});
-                else
-                    c_all_unique = unique(c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField}));
-                    if length(c_all_unique) == 1
-                        parms{parmsIndex}.(DcmComplexFieldAll{iField}) = c_all_unique;
-                    else
-                        parms{parmsIndex}.(DcmComplexFieldAll{iField}) = c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField});
-                    end
-                end
-            end
-        end
+        [parms] = xASL_bids_Dicom2JSON_FixComplexFields(DcmComplexFieldAll,DcmComplexFieldFirst,c_all_parms,c_first_parms,parmsIndex,parms);
         
-        for iField=1:length(DcmComplexFieldFirst)
-            if isfield(c_first_parms{parmsIndex},DcmComplexFieldFirst{iField}) && ~isempty(c_first_parms{parmsIndex}.(DcmComplexFieldFirst{iField}))
-                parms{parmsIndex}.(DcmComplexFieldFirst{iField}) = c_first_parms{parmsIndex}.(DcmComplexFieldFirst{iField});
-            end
-        end
         
         % Check for valid RescaleSlope value
         if isfield(parms{parmsIndex},'RescaleSlopeOriginal') && max(isnan(parms{parmsIndex}.RescaleSlopeOriginal))
@@ -757,5 +738,33 @@ function [parms,instanceNumberList,seriesNumberList] = xASL_bids_Dicom2JSON_Proc
     % Create a cell of parms
     parms{iJSON} = struct();
     
+end
+
+
+%% Fix complex fields
+function [parms] = xASL_bids_Dicom2JSON_FixComplexFields(DcmComplexFieldAll,DcmComplexFieldFirst,c_all_parms,c_first_parms,parmsIndex,parms)
+        
+        for iField=1:length(DcmComplexFieldAll)
+            if isfield(c_all_parms{parmsIndex},DcmComplexFieldAll{iField})
+                listEmptyFields = find(cellfun(@isempty,c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField})));
+                if ~isempty(listEmptyFields)
+                    fprintf('\nField %s contains empty fields, skipping... \n',DcmComplexFieldAll{iField});
+                else
+                    c_all_unique = unique(c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField}));
+                    if length(c_all_unique) == 1
+                        parms{parmsIndex}.(DcmComplexFieldAll{iField}) = c_all_unique;
+                    else
+                        parms{parmsIndex}.(DcmComplexFieldAll{iField}) = c_all_parms{parmsIndex}.(DcmComplexFieldAll{iField});
+                    end
+                end
+            end
+        end
+        
+        for iField=1:length(DcmComplexFieldFirst)
+            if isfield(c_first_parms{parmsIndex},DcmComplexFieldFirst{iField}) && ~isempty(c_first_parms{parmsIndex}.(DcmComplexFieldFirst{iField}))
+                parms{parmsIndex}.(DcmComplexFieldFirst{iField}) = c_first_parms{parmsIndex}.(DcmComplexFieldFirst{iField});
+            end
+        end
+        
 end
 

--- a/Functions/xASL_bids_Dicom2JSON.m
+++ b/Functions/xASL_bids_Dicom2JSON.m
@@ -236,36 +236,12 @@ function [parms, pathDcmDictOut] = xASL_bids_Dicom2JSON(imPar, pathIn, pathJSON,
 				end
 				
 				dicomdict('set',DictionaryDCM); % reset dictionary
-			end
+            end
 			
-			%% -----------------------------------------------------------------------------
-			% Obtain the instance number and JSON index
-			%% -----------------------------------------------------------------------------
-			if isfield(temp,'InstanceNumber') && ~isempty(temp.InstanceNumber)
-				currentInstanceNumber = temp.InstanceNumber;
-			else
-				currentInstanceNumber = 0;
-			end
-			if isfield(temp,'SeriesNumber') && ~isempty(temp.SeriesNumber)
-				currentSeriesNumber = temp.SeriesNumber;
-			else
-				currentSeriesNumber = 0;
-			end
-			
-			% First find the first matching seriesNumber
-			parmsIndex = length(instanceNumberList);
-			for iInst = length(instanceNumberList):-1:1
-				if (currentSeriesNumber == seriesNumberList(iInst))
-					parmsIndex = iInst;
-				end
-			end
-			
-			% And then the last matching instanceNumber with the correct seriesNumber
-			for iInst = 1:length(instanceNumberList)
-				if (currentInstanceNumber >= instanceNumberList(iInst)) && currentInstanceNumber>0 && currentSeriesNumber==seriesNumberList(iInst)
-					parmsIndex = iInst;
-				end
-			end
+            
+			%% Obtain the instance number and JSON index
+            [parmsIndex] = xASL_bids_Dicom2JSON_InstanceNumberJsonIndex(temp,instanceNumberList,seriesNumberList);
+            
 			
             %% Take information from the enhanced DICOM, if it exists
             [temp,iMrFileAll,iMrFile] = xASL_bids_Dicom2JSON_EnhancedDicom(temp,iMrFileAll,parmsIndex,TryDicominfo);
@@ -688,6 +664,38 @@ function [temp,iMrFileAll,iMrFile] = xASL_bids_Dicom2JSON_EnhancedDicom(temp,iMr
                     end
                 end
             end
+        end
+    end
+
+end
+
+
+%% Obtain the instance number and JSON index
+function [parmsIndex] = xASL_bids_Dicom2JSON_InstanceNumberJsonIndex(temp,instanceNumberList,seriesNumberList)
+
+    if isfield(temp,'InstanceNumber') && ~isempty(temp.InstanceNumber)
+        currentInstanceNumber = temp.InstanceNumber;
+    else
+        currentInstanceNumber = 0;
+    end
+    if isfield(temp,'SeriesNumber') && ~isempty(temp.SeriesNumber)
+        currentSeriesNumber = temp.SeriesNumber;
+    else
+        currentSeriesNumber = 0;
+    end
+
+    % First find the first matching seriesNumber
+    parmsIndex = length(instanceNumberList);
+    for iInst = length(instanceNumberList):-1:1
+        if (currentSeriesNumber == seriesNumberList(iInst))
+            parmsIndex = iInst;
+        end
+    end
+
+    % And then the last matching instanceNumber with the correct seriesNumber
+    for iInst = 1:length(instanceNumberList)
+        if (currentInstanceNumber >= instanceNumberList(iInst)) && currentInstanceNumber>0 && currentSeriesNumber==seriesNumberList(iInst)
+            parmsIndex = iInst;
         end
     end
 

--- a/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
+++ b/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
@@ -72,7 +72,7 @@ function xASL_imp_ReadSourceData_CheckFolderHierarchy(x)
     lastElement = lower(x.modules.import.imPar.folderHierarchy{end});
 
     % Condition for file extension
-    conditionFile = '\.(dcm|ima|xml|par|rec)';
+    conditionFile = '\.(dcm|ima|xml|par|rec|zip)';
 
     % Other extension
     conditionExtension = '\.';

--- a/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
+++ b/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
@@ -78,7 +78,7 @@ function x = xASL_imp_ReadSourceData_CheckFolderHierarchy(x)
     lastElement = lower(x.modules.import.imPar.folderHierarchy{end});
 
     % Condition for file extension
-    conditionFile = '(dcm|ima|xml|par|rec|zip)';
+    conditionFile = '(dcm|ima|xml|par|rec|zip|tar|gz)';
 
     % Other extension
     conditionExtension = '\.';
@@ -100,7 +100,9 @@ function x = xASL_imp_ReadSourceData_CheckFolderHierarchy(x)
             warning('Unknown extension in the last element of the folder hierarchy (%s)...',lastElement);
         end
         % Detect zipped files ("\\.(zip|dcm)" in the last element e.g.)
-        if ~isempty(regexpi(lastElement,'zip'))
+        isZip = ~isempty(regexpi(lastElement,'zip'));
+        isTarGz = ~isempty(regexpi(lastElement,'tar.gz'));
+        if isZip || isTarGz
             % Copy and unzip the sourcedata
             fprintf(2,'Copy and unzip sourcedata...\n');
             x.modules.import.dataZipped = true;
@@ -118,14 +120,22 @@ end
 
 
 
-%% Unzip all '.zip' files in subdirectories and delete original files
+%% Unzip all '.zip' or '.tar.gz' files in subdirectories and delete original files
 function xASL_imp_UnzipAll(dirToUnzip)
 
-    % Iterate over zip file
+    % Iterate over zip files
     zipFiles = xASL_adm_GetFileList(dirToUnzip,'^.+\.zip$','FPListRec');
     for iFile = 1:numel(zipFiles)
         currentDirectory = xASL_fileparts(zipFiles{iFile});
         unzip(zipFiles{iFile},currentDirectory);
+        xASL_delete(zipFiles{iFile});
+    end
+
+    % Iterate over tar.gz files
+    zipFiles = xASL_adm_GetFileList(dirToUnzip,'^.+\.tar.gz$','FPListRec');
+    for iFile = 1:numel(zipFiles)
+        currentDirectory = xASL_fileparts(zipFiles{iFile});
+        gunzip(zipFiles{iFile},currentDirectory);
         xASL_delete(zipFiles{iFile});
     end
 

--- a/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
+++ b/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
@@ -72,7 +72,7 @@ function xASL_imp_ReadSourceData_CheckFolderHierarchy(x)
     lastElement = lower(x.modules.import.imPar.folderHierarchy{end});
 
     % Condition for file extension
-    conditionFile = '\.(dcm|ima|xml|par|rec|zip)';
+    conditionFile = '(dcm|ima|xml|par|rec|zip)';
 
     % Other extension
     conditionExtension = '\.';
@@ -80,17 +80,19 @@ function xASL_imp_ReadSourceData_CheckFolderHierarchy(x)
     % Check folderHierarchy based on bMatchDirectories
     if x.modules.import.imPar.bMatchDirectories
         % Check that there is no extension in the last folder hierachy element
-        if ~isempty(regexpi(lastElement,conditionFile))
+        if ~isempty(regexpi(lastElement,conditionExtension)) && ~isempty(regexpi(lastElement,conditionFile))
            warning('The sourceStructure folderHierarchy includes a file extension...');
         end
     else
         % Check for extension in last folder hierachy element
-        if isempty(regexpi(lastElement,conditionFile))
-           if ~isempty(regexpi(lastElement,conditionExtension))
-              warning('Unknown extension in the last element of the folder hierarchy (%s)...',lastElement);
-           else
-              warning('No extension used in the last element of the folder hierarchy (%s)...',lastElement);
-           end
+        if isempty(regexpi(lastElement,conditionExtension))
+            warning('No extension used in the last element of the folder hierarchy (%s)...',lastElement);
+        elseif isempty(regexpi(lastElement,conditionFile))
+            warning('Unknown extension in the last element of the folder hierarchy (%s)...',lastElement);
+        end
+        % Detect zipped files
+        if ~isempty(regexpi(lastElement,'zip'))
+            fprintf('Zipped sourcedata detected...\n');
         end
     end
 

--- a/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
+++ b/Modules/SubModule_Import/xASL_imp_ReadSourceData.m
@@ -39,7 +39,7 @@ function x = xASL_imp_ReadSourceData(x)
     if ~x.modules.import.dataZipped
         dataDir = x.modules.import.imPar.RawRoot;
     else
-        dataDir = fullfile(x.dir.xASLDerivatives,'temp','sourcedata');
+        dataDir = fullfile(x.dir.xASLDerivatives,'tempSourcedata','sourcedata');
     end
     
     
@@ -104,7 +104,7 @@ function x = xASL_imp_ReadSourceData_CheckFolderHierarchy(x)
             % Copy and unzip the sourcedata
             fprintf(2,'Copy and unzip sourcedata...\n');
             x.modules.import.dataZipped = true;
-            newTempSource = fullfile(x.dir.xASLDerivatives,'temp','sourcedata');
+            newTempSource = fullfile(x.dir.xASLDerivatives,'tempSourcedata','sourcedata');
             xASL_Copy(x.dir.SourceData,newTempSource);
             xASL_imp_UnzipAll(newTempSource);
             % Update the x.dir field


### PR DESCRIPTION
### Linked issue

Check out #841

### How to test

I took `GE_PCASL_3Dspiral_14.0LX_1` and just zipped all the ASL and T1w data. Then I changed the `sourceStructure.json` to:

```json
{"folderHierarchy":["^(.)+$","^(ASL|T1w|M0|T2|FLAIR)$","\\.(zip|dcm)"],
"tokenOrdering":[1,0,2],
"tokenSessionAliases":["",""],
"tokenScanAliases":["^ASL$","ASL4D","^T1w$","T1w","^M0$","M0","^T2$","T2w","^FLAIR$","FLAIR"],
"bMatchDirectories":false}
```

Most of it seems to work. @jan-petr: for me it used to crash later on. Am I doing something wrong in `sourceStructure.json`?

```
ERROR: Import module terminated for subject 1: Sub103

ans =

    'Index exceeds the number of array elements (1).
     
     Error in xASL_bids_Dicom2JSON (line 419)
     	if  isfield(t_parms{parmsIndex},'AcquisitionTime')
```

I'm using this temporary fix right here https://github.com/ExploreASL/ExploreASL/pull/974#discussion_r769957679

### Comments

Optional: add helpful comments for the reviewers here

