### PR TITLE
Bug #1138 x asl wrp bids2 legacy

### DIFF
--- a/Modules/SubModule_ASL/xASL_wrp_RegisterASL.m
+++ b/Modules/SubModule_ASL/xASL_wrp_RegisterASL.m
@@ -233,6 +233,7 @@ elseif ~StructuralRawExist && ~StructuralDerivativesExist
         catVolFile = fullfile(x.D.TissueVolumeDir,['cat_' x.P.STRUCT '_' x.P.SubjectID '.mat']);
         MatFile   = fullfile(x.dir.SUBJECTDIR, [x.P.STRUCT '_seg8.mat']);
         dummyVar = [];
+        xASL_adm_CreateDir(x.D.TissueVolumeDir);
         save(catVolFile,'dummyVar');
         save(MatFile,'dummyVar');
 

--- a/Modules/xASL_wrp_BIDS2Legacy.m
+++ b/Modules/xASL_wrp_BIDS2Legacy.m
@@ -133,8 +133,9 @@ end
 fprintf('   \n');
 
 
-% Get directories of current subject
-SubjectDirs = xASL_adm_GetFileList(fullfile(x.dir.xASLDerivatives), ['^.+' x.SUBJECT '.+$'], [],[],true);
+% Get directories of current subject. The BIDS subject name can be prefixed
+% with sub- and suffixed with _1 _2 _3 etc for visits, in the legacy format
+SubjectDirs = xASL_adm_GetFileList(fullfile(x.dir.xASLDerivatives), ['^(|sub-)' x.SUBJECT '(|_\d*)$'], [],[],true);
 
 
 %% 5. Parse M0 of current subject


### PR DESCRIPTION
### Linked issue

Closes #1138
@jan-petr please also check my question in #1138.

That's on purpose - we need to know that there are all the ASL files, because for M0, we have to fill in the BIDS tag "IntendedFor", therefore we need to know what ASL files are there before processing the M0 files.