### PR TITLE
Closes #1197 xASL_module_Population: add x.S.DataTypes

### DIFF
--- a/Modules/xASL_module_Population.m
+++ b/Modules/xASL_module_Population.m
@@ -209,6 +209,8 @@ if ~x.mutex.HasState(StateName{8})
     % Default datatypes
     if ~isfield(x.S,'DataTypes')
         x.S.DataTypes = {'qCBF'}; % Default
+        % Alternatives: 'Texch' 'ATT' 'SD' 'TT' 'M0' 'R1' 'ASL_HctCohort' 'ASL_HctCorrInd'
+        % These can be added in the dataPar manually
     end
     
     
@@ -223,14 +225,13 @@ if ~x.mutex.HasState(StateName{8})
     % ROI statistics
     % x.S.SubjectWiseVisualization =1; % set this on to visualize the subject-wise masks
     % over CBF maps (takes lot of extra time though)
-    
-    x.S.InputDataStr = 'qCBF'; % 'Texch' 'ATT' 'SD' 'TT' 'M0' 'R1' 'ASL_HctCohort' 'ASL_HctCorrInd'
-	x.S.InputDataStrNative = 'CBF'; % 'Texch' 'ATT' 'SD' 'TT' 'M0' 'R1' 'ASL_HctCohort' 'ASL_HctCorrInd'
+
     
     % Iterate over DataTypes
     for iDataType=1:length(x.S.DataTypes)
         x.S.InputDataStr = x.S.DataTypes{iDataType};
-        if isempty(regexp(x.S.InputDataStr(1),'(q|r)'))
+        
+        if isempty(regexp(x.S.InputDataStr(1), '(q|r)', 'once'))
             % Some DataTypes have a prefix in standard space but not in
             % native space: e.g.,
             % qCBF in standard space is CBF in native space

--- a/Modules/xASL_module_Population.m
+++ b/Modules/xASL_module_Population.m
@@ -207,7 +207,7 @@ if ~x.mutex.HasState(StateName{8})
     end
     
     % Default datatypes
-    if ~isfield(x.S,'DataTypes')
+    if ~isfield(x.S,'DataTypes') || isempty(x.S.DataTypes)
         x.S.DataTypes = {'qCBF'}; % Default
         % Alternatives: 'Texch' 'ATT' 'SD' 'TT' 'M0' 'R1' 'ASL_HctCohort' 'ASL_HctCorrInd'
         % These can be added in the dataPar manually

--- a/Modules/xASL_module_Population.m
+++ b/Modules/xASL_module_Population.m
@@ -209,7 +209,7 @@ if ~x.mutex.HasState(StateName{8})
     % Default datatypes
     if ~isfield(x.S,'DataTypes') || isempty(x.S.DataTypes)
         x.S.DataTypes = {'qCBF'}; % Default
-        % Alternatives: 'Texch' 'ATT' 'SD' 'TT' 'M0' 'R1' 'ASL_HctCohort' 'ASL_HctCorrInd'
+        % Alternatives: 'Tex' 'ATT' 'SD' 'TT' 'M0' 'R1' 'ASL_HctCohort' 'ASL_HctCorrInd'
         % These can be added in the dataPar manually
     end
     


### PR DESCRIPTION
### Linked issue

Closes #1197

### How to test

- [x] Add "x.S.DataTypes": ["qCBF", "Texch"] to `dataPar.json` and run the population module @BeatrizPadrela to test if this new feature works
- [ ] Run the population module without this new setting to see if the default still works (it should default to `qCBF`as it originally did)

### Comments

@jan-petr Should we add this new parameter to the `dataParTemplate.md` (this is now removed and only online right?)