### PR TITLE
Closes #1326 replaced checking of file system with checking of flavors.json

### DIFF
--- a/Testing/xASL_test_Flavors.m
+++ b/Testing/xASL_test_Flavors.m
@@ -101,11 +101,6 @@ else
 	system(testConfig.cmdCloneFlavors);
 end
 
-% Check for flavor list
-if ~isfield(testConfig,'flavorList')
-	testConfig.flavorList = xASL_adm_GetFileList(testConfig.pathFlavorDatabase, [], false, [], true);
-end
-
 % Load database JSON
 if xASL_exist(fullfile(testConfig.pathFlavorDatabase,'flavors.json'),'file')
 	databaseInfo = spm_jsonread(fullfile(testConfig.pathFlavorDatabase,'flavors.json'));
@@ -114,6 +109,17 @@ else
 	error('The flavors.json file is missing...');
 end
     
+% Check for flavor list
+if ~isfield(testConfig,'flavorList')
+    List = {};
+    for iFlavor=1:length(flavors.data)
+        if flavors.data(iFlavor).bTesting
+            List{end+1,1} = flavors.data(iFlavor).name;
+        end
+    end
+    testConfig.flavorList = List;
+end    
+
 % Logging table
 flavors.loggingTable = array2table(zeros(0,3), 'VariableNames',{'message','stack','name'});
 flavors.comparisonTable = array2table(zeros(0,4), 'VariableNames',{'flavor','dataset','name','message'});

--- a/Testing/xASL_test_Flavors.m
+++ b/Testing/xASL_test_Flavors.m
@@ -111,13 +111,30 @@ end
     
 % Check for flavor list
 if ~isfield(testConfig,'flavorList')
-    List = {};
+    testConfig.directoryList = xASL_adm_GetFileList(testConfig.pathFlavorDatabase, [], false, [], true);
+
+    % Generate a list of flavors that should be tested from flavors.json
+    flavorList = {};
     for iFlavor=1:length(flavors.data)
         if flavors.data(iFlavor).bTesting
-            List{end+1,1} = flavors.data(iFlavor).name;
+            flavorList{end+1,1} = flavors.data(iFlavor).name;
         end
     end
-    testConfig.flavorList = List;
+    testConfig.flavorList = flavorList;
+
+    % Check if fields are missing in directory
+    testConfig.missingFields = setdiff(testConfig.flavorList, testConfig.directoryList);
+    if ~isempty(testConfig.missingFields)
+        warning(['Flavors specified in flavors.json are missing in directory'])
+        display(testConfig.missingFields);
+    end
+
+    % Notify of ignored flavors 
+    testConfig.ignoredFields = setdiff(testConfig.directoryList, testConfig.flavorList);
+    if ~isempty(testConfig.ignoredFields)
+        fprintf('The following flavors will be ignored as specified in flavor.json');
+        display(testConfig.ignoredFields);
+    end
 end    
 
 % Logging table


### PR DESCRIPTION
Closes #1326 

The added bTesting parameter in flavor.json is now used to check if a flavor needs testing. 

### How to test

Run Testing/xASL_test_Flavors.m

### Comments

I replaced a filesystem search with a check from flavors.json. 
Which means if a file is renamed in filesystem, but not in flavors.json it will not run in test_Flavors.m.
This can be fixed by adding the following check:
First a filesystem check xASL_adm_GetFileList(testConfig.pathFlavorDatabase, [], false, [], true);
Then a json read from the flavors.json with associated btesting value.
If both exists and btesting=true, then add it to a to be tested flavor
If flavor exists in either flavor.json or filesystem but not **both** throw a warning/error pointing the user to check it out, as this means either Flavor.json is incomplete, or the FlavorDatabase is incomplete.

