### PR TITLE
#1711 xASL_module_ASL: for 3D spiral 0->NaN

### DIFF
--- a/Modules/xASL_module_ASL.m
+++ b/Modules/xASL_module_ASL.m
@@ -219,7 +219,7 @@ x = xASL_module_ASL_ParseParameters(x, bOutput);
 % This led to a misalignment in the case of registering an ASL where the brain was too close to the edge of the FoV.
 % By setting these voxels to NaNs, the registration algorithms know to skip these voxels outside the FoV.
 
-if contains(lower(x.Q.Vendor), 'ge') && contains(lower(x.Q.MRAcquisitionType), '3d') && contains(lower(x.Q.PulseSequenceType), 'spiral')
+if ~isempty(regexpi(x.Q.Vendor, 'ge')) && ~isempty(regexpi(x.Q.MRAcquisitionType, '3d')) && ~isempty(regexpi(x.Q.PulseSequenceType, 'spiral'))
     % Once we have a GE 3D spiral sequence
     
     niftiList = {x.P.Path_ASL4D, x.P.Path_M0};

--- a/Modules/xASL_module_ASL.m
+++ b/Modules/xASL_module_ASL.m
@@ -219,7 +219,7 @@ x = xASL_module_ASL_ParseParameters(x, bOutput);
 % This led to a misalignment in the case of registering an ASL where the brain was too close to the edge of the FoV.
 % By setting these voxels to NaNs, the registration algorithms know to skip these voxels outside the FoV.
 
-if strcmpi(x.Q.Vendor, 'GE') && strcmpi(x.Q.MRAcquisitionType, '3D') && strcmpi(x.Q.PulseSequenceType, 'spiral')
+if contains(lower(x.Q.Vendor), 'ge') && contains(lower(x.Q.MRAcquisitionType), '3d') && contains(lower(x.Q.PulseSequenceType), 'spiral')
     % Once we have a GE 3D spiral sequence
     
     niftiList = {x.P.Path_ASL4D, x.P.Path_M0};


### PR DESCRIPTION
### Linked issue

Closes #1711

### How to test

I tested this with https://github.com/ExploreASL/TestDataSets/tree/main/GE_3Dspiral_misaligned_LoQ/
see issue.

### Comments

See issue, please check if you like the current location where I do this. I don't think we should change this for the BIDS conversion, this is an image processing issue.

