### PR TITLE
Closes #1914 xASL_wrp_LinearReg_T1w2MNI: bugfix matEqual definition

### DIFF
--- a/Modules/Module_Processing/Module_Structural/xASL_wrp_LinearReg_T1w2MNI.m
+++ b/Modules/Module_Processing/Module_Structural/xASL_wrp_LinearReg_T1w2MNI.m
@@ -101,6 +101,7 @@ end
 % between nii.mat0 (original orientation from the scanner)
 % and nii.mat (potential new orientation after registration)
 % If no registration happened, these are equal
+matEqual = [];
 for iCheck=1:length(checkList)
     nii = xASL_io_ReadNifti(checkList{iCheck});
     matEqual(iCheck) = isequal(nii.mat, nii.mat0);


### PR DESCRIPTION
### Linked issue

Closes #1914
