### PR TITLE
Fix: GE stores acquired pairs in NumberOfExcitations, not TotalAcquir…

### DIFF
--- a/Modules/Module_Import/NII2BIDS/xASL_bids_BIDSifyASLJSON.m
+++ b/Modules/Module_Import/NII2BIDS/xASL_bids_BIDSifyASLJSON.m
@@ -87,9 +87,11 @@ end
 
 %% 4. Convert certain DICOM fields
 %% 4a. General conversions
-% For GE, the NumberOfExcitations tag can act as a replacement for TotalAcquiredPairs
-if isfield(jsonInMerged,'NumberOfExcitations') && ~isfield(jsonInMerged, 'TotalAcquiredPairs') && ~isempty(regexpi(jsonInMerged.Manufacturer, 'GE'))
-	jsonInMerged.TotalAcquiredPairs = jsonInMerged.NumberOfExcitations;
+% For GE, use NumberOfExcitations as TotalAcquiredPairs (NEX = number of pairs)
+if isfield(jsonInMerged,'NumberOfExcitations') && ~isempty(regexpi(jsonInMerged.Manufacturer, 'GE'))
+    % Always use NumberOfExcitations for GE as it directly reflects 
+    % the number of acquired pairs, regardless of TotalAcquiredPairs
+    jsonInMerged.TotalAcquiredPairs = jsonInMerged.NumberOfExcitations;
 end
 
 % TotalAcquiredPairs - use only the maximum values from DICOM


### PR DESCRIPTION
…edPairs.


### Linked issue

The problem: When the DICOM conversion cannot find TotalAcquiredPairs in the GE DICOM header, ExploreASL falls back to a default of 1 (from NumberOfAverages in xASL_bids_Dicom2JSON.m). The existing code only checked NumberOfExcitations when TotalAcquiredPairs was completely absent, but  not when it held this wrong default of 1.

The fix: In xASL_bids_BIDSifyASLJSON.m, NumberOfExcitations is now always used as the “official” source for TotalAcquiredPairs on GE scanners, since this is the DICOM tag where GE stores the number of acquired pairs (NEX). Now it correctly identifies TotalAcquiredPairs as 4 without having to specify it in the studyPar.json. 

I hope this fix is useful. It is possible I may have overlooked something of course, please do let me know if this interferes with any other part of the pipeline or if you would prefer a different approach.

### How to test

I ran all modules and got the same results, now not needing to specify TotalAcquiredPairs in the studyPar.json and ExploreASL correctly specified 4 instead of 1 now. 

### Comments

Optional: add helpful comments for the reviewers here

